### PR TITLE
feat(API): add authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,9 @@
-CTP_PROJECT_KEY=
-CTP_CLIENT_SECRET=
-CTP_CLIENT_ID=
-CTP_AUTH_URL=
-CTP_API_URL=
-CTP_SCOPES=
+VITE_CTP_PROJECT_KEY=
+VITE_CTP_CLIENT_SECRET=
+VITE_CTP_CLIENT_ID=
+VITE_CTP_AUTH_URL=
+VITE_CTP_API_URL=
+VITE_CTP_SCOPES=
 
 
 #--------- HOW TO GET .env --------------------------------
@@ -12,6 +12,7 @@ CTP_SCOPES=
 # 2. Ask repo admin for a vault key
 # 3. Set  DOTENV_KEY variable using command line
 # 4. Run comand to decrypt .env.vault into .env
+# 5. Add VITE_ to variables in .env
 
 # 	npm i -g dotenv-vault      
 # 	DOTENV_KEY=**********

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -1,8 +1,7 @@
 export default function HomePage() {
   return (
     <div>
-      <h1>Welcome to the Home Page</h1>
-      <p>Here Must be navication and other stuff</p>
+      <h1>Welcome to the Main Page</h1>
     </div>
   );
 }

--- a/src/services/AuthService.ts
+++ b/src/services/AuthService.ts
@@ -1,0 +1,73 @@
+import axios from "axios";
+import { TokenService } from "./TokenService.js";
+
+export interface PasswordTokenResponse {
+  access_token: string;
+  expires_in: number;
+  refresh_token: string;
+  scope: string;
+  token_type: string;
+}
+
+export interface AnonymousTokenResponse extends PasswordTokenResponse {
+  anonymous_id?: string;
+}
+
+const AUTH_URL = import.meta.env.VITE_CTP_AUTH_URL;
+const PROJECT_KEY = import.meta.env.VITE_CTP_PROJECT_KEY;
+const CLIENT_ID = import.meta.env.VITE_CTP_CLIENT_ID;
+const CLIENT_SECRET = import.meta.env.VITE_CTP_CLIENT_SECRET;
+const SCOPES = import.meta.env.VITE_CTP_SCOPES;
+
+export const AuthService = {
+  authenticate: async (email: string, password: string) => {
+    const data = new URLSearchParams({
+      grant_type: "password",
+      username: email,
+      password: password,
+      scope: SCOPES,
+    }).toString();
+
+    const response = await axios.post<PasswordTokenResponse>(`${AUTH_URL}/oauth/${PROJECT_KEY}/customers/token`, data, {
+      auth: { username: CLIENT_ID, password: CLIENT_SECRET },
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    });
+
+    const { access_token, refresh_token } = response.data;
+    TokenService.setAccessToken(access_token);
+    TokenService.setRefreshToken(refresh_token);
+
+    return response.data;
+  },
+
+  refreshAccessToken: async () => {
+    const refreshToken = TokenService.getRefreshToken();
+
+    if (!refreshToken) {
+      throw new Error("Refresh token not found. User must log in again.");
+    }
+
+    const data = new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: refreshToken,
+    }).toString();
+
+    const response = await axios.post<PasswordTokenResponse>(`${AUTH_URL}/oauth/token`, data, {
+      auth: { username: CLIENT_ID, password: CLIENT_SECRET },
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+    });
+
+    const { access_token, refresh_token } = response.data;
+    TokenService.setAccessToken(access_token);
+    TokenService.setRefreshToken(refresh_token);
+
+    return access_token;
+  },
+
+  logout: () => {
+    TokenService.clearTokens();
+    window.location.href = "/login";
+  },
+};

--- a/src/services/ErrorService.ts
+++ b/src/services/ErrorService.ts
@@ -1,0 +1,18 @@
+import axios from "axios";
+
+export interface ErrorResponse {
+  statusCode: number;
+  message: string;
+  errors: { code: string; message: string }[];
+}
+
+export function serverErrorHandler(error: unknown) {
+  if (axios.isAxiosError<ErrorResponse>(error)) {
+    const errorResponse = error.response?.data;
+    if (errorResponse) {
+      const { statusCode, message } = errorResponse;
+      throw { statusCode, message };
+    }
+  }
+  throw error;
+}

--- a/src/services/TokenService.ts
+++ b/src/services/TokenService.ts
@@ -1,0 +1,16 @@
+// TokenService is an Object with set of functions to manage tokens in the storage
+
+export const TokenService = {
+  getAccessToken: (): string | null => localStorage.getItem("accessToken"),
+  setAccessToken: (token: string) => localStorage.setItem("accessToken", token),
+  removeAccessToken: () => localStorage.removeItem("accessToken"),
+
+  getRefreshToken: (): string | null => localStorage.getItem("refreshToken"),
+  setRefreshToken: (token: string) => localStorage.setItem("refreshToken", token),
+  removeRefreshToken: () => localStorage.removeItem("refreshToken"),
+
+  clearTokens: () => {
+    localStorage.removeItem("accessToken");
+    localStorage.removeItem("refreshToken");
+  },
+};

--- a/src/services/apiClient.ts
+++ b/src/services/apiClient.ts
@@ -1,0 +1,47 @@
+import axios from "axios";
+import type { AxiosInstance } from "axios";
+import { TokenService } from "./TokenService";
+import { AuthService } from "./AuthService";
+
+const API_URL = import.meta.env.VITE_CTP_API_URL;
+
+export const apiClient: AxiosInstance = axios.create({
+  baseURL: API_URL,
+
+  headers: {
+    "Content-Type": "application/json",
+  },
+});
+
+// request interceptor automatically adds Authorization header if token exists
+apiClient.interceptors.request.use((config) => {
+  const token = TokenService.getAccessToken();
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+// response interceptor automatically intercepts response and refresh keys if possible
+apiClient.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest = error.config;
+
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      originalRequest._retry = true;
+
+      try {
+        const newAccessToken = await AuthService.refreshAccessToken();
+        originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+
+        return apiClient(originalRequest);
+      } catch (refreshError) {
+        console.error("Token refresh failed:", refreshError);
+        AuthService.logout();
+      }
+    }
+
+    return Promise.reject(error);
+  }
+);

--- a/src/services/apiClient.ts
+++ b/src/services/apiClient.ts
@@ -2,6 +2,7 @@ import axios from "axios";
 import type { AxiosInstance } from "axios";
 import { TokenService } from "./TokenService";
 import { AuthService } from "./AuthService";
+import { serverErrorHandler } from "./ErrorService";
 
 const API_URL = import.meta.env.VITE_CTP_API_URL;
 
@@ -23,6 +24,7 @@ apiClient.interceptors.request.use((config) => {
 });
 
 // response interceptor automatically intercepts response and refresh keys if possible
+// catches error for all apiClient functions
 apiClient.interceptors.response.use(
   (response) => response,
   async (error) => {
@@ -41,7 +43,7 @@ apiClient.interceptors.response.use(
         AuthService.logout();
       }
     }
-
-    return Promise.reject(error);
+    const handledError = serverErrorHandler(error);
+    return Promise.reject(handledError);
   }
 );

--- a/src/services/customerService/customerService.ts
+++ b/src/services/customerService/customerService.ts
@@ -1,13 +1,17 @@
 import { apiClient } from "../apiClient";
+import type { CustomerResponse, CartResponse } from "./types";
 
 const API_URL = import.meta.env.VITE_CTP_API_URL;
 const PROJECT_KEY = import.meta.env.VITE_CTP_PROJECT_KEY;
 
 export async function signIn(email: string, password: string) {
-  const response = await apiClient.post(`${API_URL}/${PROJECT_KEY}/login`, {
-    email,
-    password,
-  });
+  const response = await apiClient.post<{ customer: CustomerResponse; cart: CartResponse }>(
+    `${API_URL}/${PROJECT_KEY}/login`,
+    {
+      email,
+      password,
+    }
+  );
 
   const { customer, cart } = response.data;
   return { customer, cart };

--- a/src/services/customerService/customerService.ts
+++ b/src/services/customerService/customerService.ts
@@ -1,0 +1,14 @@
+import { apiClient } from "../apiClient";
+
+const API_URL = import.meta.env.VITE_CTP_API_URL;
+const PROJECT_KEY = import.meta.env.VITE_CTP_PROJECT_KEY;
+
+export async function signIn(email: string, password: string) {
+  const response = await apiClient.post(`${API_URL}/${PROJECT_KEY}/login`, {
+    email,
+    password,
+  });
+
+  const { customer, cart } = response.data;
+  return { customer, cart };
+}

--- a/src/services/customerService/types.ts
+++ b/src/services/customerService/types.ts
@@ -1,0 +1,17 @@
+interface Address {
+  country: string;
+}
+export interface CartResponse {
+  id: string;
+  version: number;
+}
+export interface CustomerResponse {
+  id: string;
+  version: number;
+  email: string;
+  addresses: Address[];
+  isEmailVerified: boolean;
+  authenticationMode: "Password" | "ExternalAuth";
+  createdAt: Date;
+  lastModifiedAt: Date;
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,14 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_CTP_PROJECT_KEY: string;
+  readonly VITE_CTP_CLIENT_SECRET: string;
+  readonly VITE_CTP_CLIENT_ID: string;
+  readonly VITE_CTP_AUTH_URL: string;
+  readonly VITE_CTP_API_URL: string;
+  readonly VITE_CTP_SCOPES: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
Added authentication and API services.

**oauth token** is stored in localstorage, refresh token also there. If token in local storage - it means that the customer is logged in, to logout the customer it's enough to remove the token from local storage.

Key points:
 - **Token service** - contains functions for managing oauth token in local storage.
 - Don't forget to add **VITE_** prefix in env.
 - auth service handles auth flows - for now there is password flow and refresh token flow.
- apiClient service - manages refresh token and with axios interceptors simplifies further  API development
- customerService will be containing API calls related to customer
- in login page added additional functional to handle Commercetools authentication
- added error catching mechanism to interceptor for centralize error catching for all endpoints


Next steps: 
 - create **logout button** on the header to logout the customer
 - when client is logged in **login button must change on logout button** 
 - logout button must delete token key from local storage and redirect client to the main page
 
 
There is an issue that must be solved - if the client is logged in, redirection in the current implementation  works but you can see the rendering for ms after redirection, need to find better solution. Current solution: 

```ts
const isLoggedIn = TokenService.getAccessToken();
  const navigate = useNavigate();
  useEffect(() => {
    if (isLoggedIn) {
      navigate("/");
    }
  }, [isLoggedIn, navigate]);
```
