### PR TITLE
feat(frontend): establish storefront UI foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ eslint.config.js
 *.sln
 *.sw?
 .flaskenv*
+/design-reference

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "test:watch": "vitest --watch"
   },
   "dependencies": {
+    "@fontsource/roboto": "^5.3.0",
     "axios": "^1.18.1",
     "react": "19.1.0",
     "react-dom": "19.1.0",

--- a/frontend/src/assets/styles/_tokens.scss
+++ b/frontend/src/assets/styles/_tokens.scss
@@ -1,0 +1,67 @@
+$breakpoint-mobile: 48rem;
+$breakpoint-tablet: 76.8rem;
+$breakpoint-desktop: 120rem;
+
+:root {
+  --color-ink: #000000;
+  --color-surface: #ffffff;
+  --color-surface-subtle: #f0f0f0;
+  --color-surface-hero: #f2f0f1;
+  --color-border: #f0eeed;
+  --color-text-muted: rgb(0 0 0 / 60%);
+  --color-text-subtle: rgb(0 0 0 / 40%);
+  --color-danger: #ff3333;
+  --color-rating: #ffc633;
+  --color-success: #01ab31;
+
+  --font-family-body: "Roboto", "Helvetica Neue", Arial, sans-serif;
+  --font-family-heading: "Roboto", "Helvetica Neue", Arial, sans-serif;
+
+  --font-size-xs: 1.2rem;
+  --font-size-sm: 1.4rem;
+  --font-size-md: 1.6rem;
+  --font-size-lg: 2rem;
+  --font-size-xl: 2.4rem;
+  --font-size-2xl: 3.2rem;
+  --font-size-3xl: 4rem;
+  --font-size-4xl: 4.8rem;
+  --font-size-hero: 6.4rem;
+
+  --line-height-tight: 1;
+  --line-height-heading: 1.15;
+  --line-height-body: 1.375;
+  --line-height-relaxed: 1.5;
+
+  --font-weight-regular: 400;
+  --font-weight-medium: 500;
+  --font-weight-bold: 700;
+
+  --space-1: 0.4rem;
+  --space-2: 0.8rem;
+  --space-3: 1.2rem;
+  --space-4: 1.6rem;
+  --space-5: 2rem;
+  --space-6: 2.4rem;
+  --space-8: 3.2rem;
+  --space-10: 4rem;
+  --space-12: 4.8rem;
+  --space-16: 6.4rem;
+  --space-20: 8rem;
+  --space-25: 10rem;
+
+  --radius-sm: 0.8rem;
+  --radius-md: 2rem;
+  --radius-lg: 4rem;
+  --radius-pill: 999rem;
+
+  --border-subtle: 1px solid var(--color-border);
+  --shadow-focus: 0 0 0 3px rgb(0 0 0 / 18%);
+
+  --container-max-width: 124rem;
+  --container-gutter: 10rem;
+  --container-gutter-tablet: 3.2rem;
+  --container-gutter-mobile: 1.6rem;
+
+  --transition-fast: 150ms ease;
+  --transition-base: 250ms ease;
+}

--- a/frontend/src/assets/styles/_tokens.scss
+++ b/frontend/src/assets/styles/_tokens.scss
@@ -23,6 +23,7 @@ $breakpoint-desktop: 120rem;
   --font-size-lg: 2rem;
   --font-size-xl: 2.4rem;
   --font-size-2xl: 3.2rem;
+  --font-size-hero-mobile: 3.6rem;
   --font-size-3xl: 4rem;
   --font-size-4xl: 4.8rem;
   --font-size-hero: 6.4rem;

--- a/frontend/src/assets/styles/global.scss
+++ b/frontend/src/assets/styles/global.scss
@@ -1,3 +1,5 @@
+@use "./tokens";
+
 * {
   margin: 0;
   padding: 0;
@@ -16,4 +18,35 @@ body,
 
 body {
   margin: 0 auto;
+  min-width: 32rem;
+  background: var(--color-surface);
+  color: var(--color-ink);
+  font-family: var(--font-family-body);
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-regular);
+  line-height: var(--line-height-body);
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+}
+
+button,
+input,
+select,
+textarea {
+  color: inherit;
+  font: inherit;
+}
+
+button,
+a {
+  -webkit-tap-highlight-color: transparent;
+}
+
+button:focus-visible,
+a:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+  outline: none;
+  box-shadow: var(--shadow-focus);
 }

--- a/frontend/src/components/common/IconButton/IconButton.scss
+++ b/frontend/src/components/common/IconButton/IconButton.scss
@@ -1,0 +1,60 @@
+.icon-button {
+  --icon-button-size: 4rem;
+  --icon-button-glyph-size: 2.4rem;
+
+  display: inline-flex;
+  width: var(--icon-button-size);
+  height: var(--icon-button-size);
+  padding: 0;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  border: 0;
+  border-radius: var(--radius-pill);
+  appearance: none;
+  color: inherit;
+  cursor: pointer;
+  transition:
+    opacity var(--transition-fast),
+    transform var(--transition-fast);
+
+  &:not(:disabled):hover {
+    opacity: 0.7;
+  }
+
+  &:not(:disabled):active {
+    transform: scale(0.94);
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.4;
+  }
+}
+
+.icon-button--small {
+  --icon-button-size: 3.2rem;
+  --icon-button-glyph-size: 2rem;
+}
+
+.icon-button--ghost {
+  background-color: transparent;
+}
+
+.icon-button--subtle {
+  background-color: var(--color-surface-subtle);
+}
+
+.icon-button__icon {
+  display: inline-flex;
+  width: var(--icon-button-glyph-size);
+  height: var(--icon-button-glyph-size);
+  align-items: center;
+  justify-content: center;
+
+  > img,
+  > svg {
+    width: 100%;
+    height: 100%;
+  }
+}

--- a/frontend/src/components/common/IconButton/IconButton.spec.tsx
+++ b/frontend/src/components/common/IconButton/IconButton.spec.tsx
@@ -1,0 +1,48 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { IconButton } from "./IconButton";
+
+describe("IconButton", () => {
+  it("uses its label as the accessible name and handles clicks", () => {
+    const handleClick = vi.fn();
+
+    render(<IconButton icon={<svg data-testid="menu-icon" />} label="Open menu" onClick={handleClick} />);
+
+    const button = screen.getByRole("button", { name: "Open menu" });
+    const icon = screen.getByTestId("menu-icon");
+
+    expect(button).toHaveClass("icon-button", "icon-button--medium", "icon-button--ghost");
+    expect(button).toHaveAttribute("type", "button");
+    expect(icon.parentElement).toHaveAttribute("aria-hidden", "true");
+
+    fireEvent.click(button);
+    expect(handleClick).toHaveBeenCalledOnce();
+  });
+
+  it("forwards native state and prevents clicks when disabled", () => {
+    const handleClick = vi.fn();
+
+    render(
+      <IconButton
+        aria-pressed="false"
+        className="filter-button"
+        disabled
+        icon={<svg />}
+        label="Open filters"
+        onClick={handleClick}
+        size="small"
+        variant="subtle"
+      />
+    );
+
+    const button = screen.getByRole("button", { name: "Open filters" });
+
+    expect(button).toHaveClass("icon-button--small", "icon-button--subtle", "filter-button");
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute("aria-pressed", "false");
+
+    fireEvent.click(button);
+    expect(handleClick).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/common/IconButton/IconButton.tsx
+++ b/frontend/src/components/common/IconButton/IconButton.tsx
@@ -1,0 +1,33 @@
+import type { ComponentPropsWithoutRef, ReactNode } from "react";
+
+import "./IconButton.scss";
+
+type IconButtonSize = "medium" | "small";
+type IconButtonVariant = "ghost" | "subtle";
+
+type IconButtonProps = Omit<ComponentPropsWithoutRef<"button">, "aria-label" | "children"> & {
+  label: string;
+  icon: ReactNode;
+  size?: IconButtonSize;
+  variant?: IconButtonVariant;
+};
+
+export function IconButton({
+  label,
+  icon,
+  size = "medium",
+  variant = "ghost",
+  type = "button",
+  className = "",
+  ...props
+}: IconButtonProps) {
+  const classes = `icon-button icon-button--${size} icon-button--${variant} ${className}`.trim();
+
+  return (
+    <button {...props} aria-label={label} className={classes} type={type}>
+      <span aria-hidden="true" className="icon-button__icon">
+        {icon}
+      </span>
+    </button>
+  );
+}

--- a/frontend/src/components/common/PageContainer/PageContainer.scss
+++ b/frontend/src/components/common/PageContainer/PageContainer.scss
@@ -1,0 +1,21 @@
+@use "../../../assets/styles/tokens" as tokens;
+
+.page-container {
+  --page-container-gutter: var(--container-gutter);
+
+  width: calc(100% - var(--page-container-gutter) - var(--page-container-gutter));
+  max-width: var(--container-max-width);
+  margin-inline: auto;
+}
+
+@media (max-width: tokens.$breakpoint-desktop) {
+  .page-container {
+    --page-container-gutter: var(--container-gutter-tablet);
+  }
+}
+
+@media (max-width: tokens.$breakpoint-tablet) {
+  .page-container {
+    --page-container-gutter: var(--container-gutter-mobile);
+  }
+}

--- a/frontend/src/components/common/PageContainer/PageContainer.spec.tsx
+++ b/frontend/src/components/common/PageContainer/PageContainer.spec.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { PageContainer } from "./PageContainer";
+
+describe("PageContainer", () => {
+  it("renders its content and forwards native div attributes", () => {
+    render(
+      <PageContainer aria-label="Page content" className="catalog-layout">
+        <span>Catalog</span>
+      </PageContainer>
+    );
+
+    const container = screen.getByLabelText("Page content");
+
+    expect(container).toHaveClass("page-container", "catalog-layout");
+    expect(screen.getByText("Catalog")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/common/PageContainer/PageContainer.tsx
+++ b/frontend/src/components/common/PageContainer/PageContainer.tsx
@@ -1,0 +1,11 @@
+import type { ComponentPropsWithoutRef } from "react";
+
+import "./PageContainer.scss";
+
+type PageContainerProps = ComponentPropsWithoutRef<"div">;
+
+export function PageContainer({ className = "", ...props }: PageContainerProps) {
+  const classes = `page-container ${className}`.trim();
+
+  return <div className={classes} {...props} />;
+}

--- a/frontend/src/components/common/button/button.scss
+++ b/frontend/src/components/common/button/button.scss
@@ -1,62 +1,72 @@
 .btn {
-  // general btn styling
-  display: flex;
-  width: 100%; // should be adjustmed in use
-  max-width: 400px; // better to set to each btn separately
-  height: 52px;
-  padding: 16px 54px;
+  display: inline-flex;
+  width: 100%;
+  max-width: 40rem;
+  height: 5.2rem;
+  padding: var(--space-4) 5.4rem;
   justify-content: center;
   align-items: center;
-  gap: 12px;
+  gap: var(--space-3);
   flex-shrink: 0;
-  border-radius: 62px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-pill);
+  appearance: none;
 
-  // typography for button text
-  color: #fff;
-  font-family: "Roboto", sans-serif;
-  font-size: 16px;
+  font-family: var(--font-family-body);
+  font-size: var(--font-size-md);
   font-style: normal;
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
   line-height: normal;
+  cursor: pointer;
+  transition:
+    opacity var(--transition-fast),
+    transform var(--transition-fast);
 
   &:not(:disabled):hover {
     opacity: 0.8;
   }
+
   &:not(:disabled):active {
     transform: scale(0.98);
   }
 
   &:disabled,
   &.btn--disabled {
-    background-color: #f0f0f0;
-    color: #ddd;
     cursor: not-allowed;
+    opacity: 0.4;
   }
 }
 
 .btn-medium {
-  padding: 8px 8px;
-  height: 42px;
-  font-size: 14px;
-  line-height: 1.5;
-  border-radius: 16px;
+  height: 4.2rem;
+  padding: var(--space-2);
+  border-radius: var(--radius-pill);
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-relaxed);
 }
 
-// Dark variant: black background, white text (.btn--dark)
 .btn--dark {
-  background-color: #000;
-  color: #fff;
-
-  &:disabled,
-  &.btn--dark--disabled {
-    background-color: #000;
-    opacity: 0.5;
-  }
+  background-color: var(--color-ink);
+  color: var(--color-surface);
 }
 
-// Light variant: white background, black text (.btn--light)
 .btn--light {
-  background-color: #fff;
-  color: #000;
-  border: 1px solid #000;
+  border-color: var(--color-border);
+  background-color: var(--color-surface);
+  color: var(--color-ink);
+}
+
+.button-icon {
+  display: inline-flex;
+  width: 2.4rem;
+  height: 2.4rem;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+
+  > img,
+  > svg {
+    width: 100%;
+    height: 100%;
+  }
 }

--- a/frontend/src/components/common/button/button.spec.tsx
+++ b/frontend/src/components/common/button/button.spec.tsx
@@ -1,0 +1,44 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import Button from "./button";
+
+describe("Button", () => {
+  it("renders the dark variant by default and handles clicks", () => {
+    const handleClick = vi.fn();
+
+    render(<Button name="shop" onClick={handleClick} text="Shop now" />);
+
+    const button = screen.getByRole("button", { name: "Shop now" });
+
+    expect(button).toHaveClass("btn", "btn--dark");
+    expect(button).toHaveAttribute("name", "shop");
+    expect(button).toHaveAttribute("type", "button");
+
+    fireEvent.click(button);
+    expect(handleClick).toHaveBeenCalledOnce();
+  });
+
+  it("renders the light variant, icon and disabled state", () => {
+    const handleClick = vi.fn();
+
+    render(
+      <Button
+        disabled
+        icon={<svg aria-label="Edit icon" />}
+        onClick={handleClick}
+        text="Edit profile"
+        variant="light"
+      />
+    );
+
+    const button = screen.getByRole("button", { name: "Edit icon Edit profile" });
+
+    expect(button).toHaveClass("btn--light", "btn--disabled");
+    expect(button).toBeDisabled();
+    expect(button.querySelector(".button-icon")).toBeInTheDocument();
+
+    fireEvent.click(button);
+    expect(handleClick).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/common/button/button.tsx
+++ b/frontend/src/components/common/button/button.tsx
@@ -1,31 +1,27 @@
-import React from "react";
+import type { ComponentPropsWithoutRef, ReactNode } from "react";
 
 import "./button.scss";
 
-type ButtonProps = {
-  text: string; // The button's text label
-  variant?: "dark" | "light"; // Choose between black-bg or white-bg styles (dark by default)
-  onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void; // Optional click handler function
-  className?: string; // Optional add class/classes
-  disabled?: boolean;
-  type?: "button" | "reset" | "submit";
-  icon?: React.ReactNode;
+type ButtonProps = Omit<ComponentPropsWithoutRef<"button">, "children"> & {
+  text: string;
+  variant?: "dark" | "light";
+  icon?: ReactNode;
 };
 
-const Button: React.FC<ButtonProps> = ({
+const Button = ({
   type = "button",
   text,
-  variant = "dark", // Default to the dark variant if none provided
-  onClick,
+  variant = "dark",
   className = "",
   disabled = false,
   icon,
-}) => {
+  ...props
+}: ButtonProps) => {
   const stateClass = disabled ? "btn--disabled" : "";
   const btnClass = `btn btn--${variant} ${stateClass} ${className}`.trim();
 
   return (
-    <button className={btnClass} onClick={onClick} disabled={disabled} type={type}>
+    <button {...props} className={btnClass} disabled={disabled} type={type}>
       {icon && <span className="button-icon">{icon}</span>}
       {text}
     </button>

--- a/frontend/src/components/common/headings/H1.tsx
+++ b/frontend/src/components/common/headings/H1.tsx
@@ -1,16 +1,17 @@
-import React from "react";
+import type { ComponentPropsWithoutRef } from "react";
+
 import "./headings.scss";
 
-//h1 - main page banner title
-//h2 - page titles, section titles
-//h3 - product title
-
-type H1Props = {
+type H1Props = Omit<ComponentPropsWithoutRef<"h1">, "children"> & {
   text: string;
-  className?: string;
 };
 
-export const H1: React.FC<H1Props> = ({ text, className = "" }) => {
+export const H1 = ({ text, className = "", ...props }: H1Props) => {
   const classes = `heading h1 ${className}`.trim();
-  return <h1 className={classes}>{text}</h1>;
+
+  return (
+    <h1 {...props} className={classes}>
+      {text}
+    </h1>
+  );
 };

--- a/frontend/src/components/common/headings/H2.tsx
+++ b/frontend/src/components/common/headings/H2.tsx
@@ -1,16 +1,17 @@
-import React from "react";
+import type { ComponentPropsWithoutRef } from "react";
+
 import "./headings.scss";
 
-//h1 - main page banner title
-//h2 - page titles, section titles
-//h3 - product title
-
-type H2Props = {
+type H2Props = Omit<ComponentPropsWithoutRef<"h2">, "children"> & {
   text: string;
-  className?: string;
 };
 
-export const H2: React.FC<H2Props> = ({ text, className = "" }) => {
+export const H2 = ({ text, className = "", ...props }: H2Props) => {
   const classes = `heading h2 ${className}`.trim();
-  return <h2 className={classes}>{text}</h2>;
+
+  return (
+    <h2 {...props} className={classes}>
+      {text}
+    </h2>
+  );
 };

--- a/frontend/src/components/common/headings/H3.tsx
+++ b/frontend/src/components/common/headings/H3.tsx
@@ -1,16 +1,17 @@
-import React from "react";
+import type { ComponentPropsWithoutRef } from "react";
+
 import "./headings.scss";
 
-//h1 - main page banner title
-//h2 - page titles, section titles
-//h3 - product title
-
-type H3Props = {
+type H3Props = Omit<ComponentPropsWithoutRef<"h3">, "children"> & {
   text: string;
-  className?: string;
 };
 
-export const H3: React.FC<H3Props> = ({ text, className = "" }) => {
+export const H3 = ({ text, className = "", ...props }: H3Props) => {
   const classes = `heading h3 ${className}`.trim();
-  return <h3 className={classes}>{text}</h3>;
+
+  return (
+    <h3 {...props} className={classes}>
+      {text}
+    </h3>
+  );
 };

--- a/frontend/src/components/common/headings/headings.scss
+++ b/frontend/src/components/common/headings/headings.scss
@@ -1,21 +1,37 @@
+@use "../../../assets/styles/tokens" as tokens;
+
 .heading {
-  font-family: "Roboto", sans-serif;
-  font-style: normal;
   margin: 0;
+  color: inherit;
+  font-family: var(--font-family-heading);
+  font-style: normal;
+  font-weight: var(--font-weight-bold);
+  line-height: var(--line-height-heading);
 }
 
 .h1 {
-  font-size: 64px;
-  font-weight: 700;
-  line-height: 64px;
+  font-size: var(--font-size-hero);
+  line-height: var(--line-height-tight);
 }
 
 .h2 {
-  font-size: 48px;
-  font-weight: 700;
+  font-size: var(--font-size-4xl);
 }
 
 .h3 {
-  font-size: 40px;
-  font-weight: 700;
+  font-size: var(--font-size-2xl);
+}
+
+@media (max-width: tokens.$breakpoint-tablet) {
+  .h1 {
+    font-size: var(--font-size-hero-mobile);
+  }
+
+  .h2 {
+    font-size: var(--font-size-2xl);
+  }
+
+  .h3 {
+    font-size: var(--font-size-xl);
+  }
 }

--- a/frontend/src/components/common/headings/headings.spec.tsx
+++ b/frontend/src/components/common/headings/headings.spec.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { H1 } from "./H1";
+import { H2 } from "./H2";
+import { H3 } from "./H3";
+
+describe("headings", () => {
+  it("renders the correct semantic heading levels", () => {
+    render(
+      <>
+        <H1 text="Storefront" />
+        <H2 text="New arrivals" />
+        <H3 text="Casual" />
+      </>
+    );
+
+    expect(screen.getByRole("heading", { level: 1, name: "Storefront" })).toHaveClass("heading", "h1");
+    expect(screen.getByRole("heading", { level: 2, name: "New arrivals" })).toHaveClass("heading", "h2");
+    expect(screen.getByRole("heading", { level: 3, name: "Casual" })).toHaveClass("heading", "h3");
+  });
+
+  it("forwards native heading attributes and custom classes", () => {
+    render(<H2 aria-label="Catalog heading" className="catalog-title" id="catalog" text="Products" />);
+
+    const heading = screen.getByRole("heading", { level: 2, name: "Catalog heading" });
+
+    expect(heading).toHaveClass("heading", "h2", "catalog-title");
+    expect(heading).toHaveAttribute("id", "catalog");
+  });
+});

--- a/frontend/src/components/common/inputField/inputField.scss
+++ b/frontend/src/components/common/inputField/inputField.scss
@@ -1,62 +1,95 @@
 .input-wrapper {
   position: relative;
   display: flex;
+  width: 100%;
   align-items: center;
+}
 
-  .input-icon {
-    position: absolute;
-    top: 16px;
-    left: 14px;
-    color: #aaa;
-    pointer-events: none;
-  }
+.input-icon,
+.input-right-icon {
+  position: absolute;
+  z-index: 1;
+  top: 50%;
+  display: inline-flex;
+  width: 2.4rem;
+  height: 2.4rem;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text-subtle);
+  transform: translateY(-50%);
 
-  .input-right-icon {
-    position: absolute;
-    top: 12px;
-    right: 16px;
-    color: #aaa;
-    font-size: 1.75rem;
+  img,
+  svg {
+    width: 100%;
+    height: 100%;
   }
+}
+
+.input-icon {
+  inset-inline-start: var(--space-4);
+  pointer-events: none;
+}
+
+.input-right-icon {
+  inset-inline-end: var(--space-4);
 }
 
 .input {
-  width: 100%; // Full-width by default
-  font-family: "Roboto", sans-serif;
-  font-size: 16px;
+  width: 100%;
+  min-height: 4.8rem;
+  padding: var(--space-3) var(--space-4);
+  border: 1px solid transparent;
+  border-radius: var(--radius-pill);
+  background: var(--color-surface-subtle);
+  color: var(--color-ink);
+  font-family: var(--font-family-body);
+  font-size: var(--font-size-md);
   font-style: normal;
-  font-weight: 500;
-  line-height: normal;
-  color: #0000004d;
-  padding: 12px 30px;
-  justify-content: center;
-  align-items: center;
-  gap: 12px;
-  border-radius: 62px;
-  border-width: 0px;
-  border-color: #ffffff;
-  // background: #F0F0F0;
-  background: #ffffff;
+  font-weight: var(--font-weight-regular);
+  line-height: var(--line-height-body);
+  transition:
+    border-color var(--transition-fast),
+    opacity var(--transition-fast);
 
-  // Focus state to aid accessibility
-  &:focus,
-  &:focus-visible {
-    border-color: #000;
-    border-width: 1px;
-    color: #000;
+  &::placeholder {
+    color: var(--color-text-subtle);
+    opacity: 1;
   }
 
-  // Disabled state
+  &:focus,
+  &:focus-visible {
+    border-color: var(--color-ink);
+  }
+
   &:disabled {
-    background-color: #ffffff; // Light gray background
-    color: #777; // Gray text
-    cursor: not-allowed; // Disabled cursor
+    color: var(--color-text-muted);
+    cursor: not-allowed;
+    opacity: 0.6;
   }
 }
 
-// Error state styling
-.input--error {
-  border-color: #ff3333;
-  border-width: 1px;
-  color: #ff3333;
+.input-wrapper--with-leading-icon .input:not([type="checkbox"]) {
+  padding-inline-start: 5.2rem;
+}
+
+.input-wrapper--with-trailing-icon .input:not([type="checkbox"]) {
+  padding-inline-end: 5.2rem;
+}
+
+.input[type="checkbox"] {
+  width: 2rem;
+  height: 2rem;
+  min-height: auto;
+  padding: 0;
+  flex: 0 0 auto;
+  accent-color: var(--color-ink);
+}
+
+.input.input--error {
+  border-color: var(--color-danger);
+}
+
+.input-wrapper--error .input-icon,
+.input-wrapper--error .input-right-icon {
+  color: var(--color-danger);
 }

--- a/frontend/src/components/common/inputField/inputField.spec.tsx
+++ b/frontend/src/components/common/inputField/inputField.spec.tsx
@@ -1,0 +1,58 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import InputField from "./inputField";
+
+describe("InputField", () => {
+  it("forwards native input attributes and returns the changed value", () => {
+    const handleChange = vi.fn();
+
+    render(
+      <InputField
+        autoComplete="email"
+        name="email"
+        onChange={handleChange}
+        placeholder="Email address"
+        required
+        value=""
+      />
+    );
+
+    const input = screen.getByPlaceholderText("Email address");
+
+    expect(input).toHaveAttribute("autocomplete", "email");
+    expect(input).toBeRequired();
+    expect(input).toHaveAttribute("aria-invalid", "false");
+
+    fireEvent.change(input, { target: { value: "shop@example.com" } });
+    expect(handleChange).toHaveBeenCalledWith("shop@example.com");
+  });
+
+  it("renders icons, custom classes and the invalid state", () => {
+    render(
+      <InputField
+        icon={<svg data-testid="leading-icon" />}
+        inputClassName="promo-input"
+        isValid={false}
+        onChange={vi.fn()}
+        rightIcon={<button aria-label="Clear input" type="button" />}
+        value="PROMO"
+        wrapperClassName="promo-input-wrapper"
+      />
+    );
+
+    const input = screen.getByDisplayValue("PROMO");
+    const wrapper = input.parentElement;
+
+    expect(input).toHaveClass("input", "input--error", "promo-input");
+    expect(input).toHaveAttribute("aria-invalid", "true");
+    expect(wrapper).toHaveClass(
+      "input-wrapper--with-leading-icon",
+      "input-wrapper--with-trailing-icon",
+      "input-wrapper--error",
+      "promo-input-wrapper"
+    );
+    expect(screen.getByTestId("leading-icon")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Clear input" })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/common/inputField/inputField.tsx
+++ b/frontend/src/components/common/inputField/inputField.tsx
@@ -1,45 +1,56 @@
-import React from "react";
+import type { ComponentPropsWithoutRef, ReactNode } from "react";
+
 import "./inputField.scss";
 
-type InputFieldProps = {
-  value: string; // The input's value
-  onChange: (newValue: string) => void; // Function to call when text changes
-  placeholder?: string; // Optional placeholder text
-  name?: string;
-  disabled?: boolean; // Disable interaction
-  isValid?: boolean; // Mark input as invalid
+type InputFieldProps = Omit<ComponentPropsWithoutRef<"input">, "children" | "className" | "onChange" | "value"> & {
+  value: string;
+  onChange: (newValue: string) => void;
+  isValid?: boolean;
   wrapperClassName?: string;
   inputClassName?: string;
-  type?: string;
-  icon?: React.ReactNode;
-  rightIcon?: React.ReactNode;
+  icon?: ReactNode;
+  rightIcon?: ReactNode;
 };
 
-const InputField: React.FC<InputFieldProps> = ({
+const InputField = ({
   value,
   onChange,
   placeholder = "",
   name = "",
-  disabled = false, // Default to enabled
-  isValid = true, // Default to valid
+  disabled = false,
+  isValid = true,
   wrapperClassName = "",
   inputClassName = "",
   type = "text",
   icon,
   rightIcon,
-}) => {
+  ...props
+}: InputFieldProps) => {
   const errorClass = isValid ? "" : "input--error";
   const inputClass = `input ${errorClass} ${inputClassName}`.trim();
-  const wrapperClass = `input-wrapper ${wrapperClassName}`.trim();
+  const wrapperClass = [
+    "input-wrapper",
+    icon && "input-wrapper--with-leading-icon",
+    rightIcon && "input-wrapper--with-trailing-icon",
+    !isValid && "input-wrapper--error",
+    wrapperClassName,
+  ]
+    .filter(Boolean)
+    .join(" ");
 
   return (
     <div className={wrapperClass}>
-      {icon && <span className="input-icon">{icon}</span>}
+      {icon && (
+        <span aria-hidden="true" className="input-icon">
+          {icon}
+        </span>
+      )}
       <input
+        {...props}
         className={inputClass}
         type={type}
         value={value}
-        onChange={(e) => onChange(e.target.value)}
+        onChange={(event) => onChange(event.currentTarget.value)}
         placeholder={placeholder}
         name={name}
         disabled={disabled}
@@ -50,5 +61,4 @@ const InputField: React.FC<InputFieldProps> = ({
   );
 };
 
-// Export the InputField component for use elsewhere
 export default InputField;

--- a/frontend/src/components/common/link/link.scss
+++ b/frontend/src/components/common/link/link.scss
@@ -1,11 +1,38 @@
 .link {
-  font-family: "Roboto", sans-serif;
-  font-size: 16px;
-  color: #000;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  color: inherit;
+  font-family: var(--font-family-body);
+  font-size: var(--font-size-md);
+  font-style: normal;
+  font-weight: var(--font-weight-regular);
+  line-height: normal;
   text-decoration: none;
+  text-underline-offset: 0.2em;
   cursor: pointer;
+  transition: opacity var(--transition-fast);
 
   &:hover {
     text-decoration: underline;
+  }
+
+  &:active {
+    opacity: 0.6;
+  }
+}
+
+.link-icon {
+  display: inline-flex;
+  width: 2.4rem;
+  height: 2.4rem;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+
+  > img,
+  > svg {
+    width: 100%;
+    height: 100%;
   }
 }

--- a/frontend/src/components/common/link/link.spec.tsx
+++ b/frontend/src/components/common/link/link.spec.tsx
@@ -1,0 +1,30 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import Link from "./link";
+
+describe("Link", () => {
+  it("renders a real anchor and forwards native attributes", () => {
+    const handleClick = vi.fn();
+
+    render(<Link className="catalog-link" href="/catalog" onClick={handleClick} target="_blank" text="Catalog" />);
+
+    const link = screen.getByRole("link", { name: "Catalog" });
+
+    expect(link).toHaveClass("link", "catalog-link");
+    expect(link).toHaveAttribute("href", "/catalog");
+    expect(link).toHaveAttribute("target", "_blank");
+
+    fireEvent.click(link);
+    expect(handleClick).toHaveBeenCalledOnce();
+  });
+
+  it("renders an icon before the link text", () => {
+    render(<Link href="/basket" icon={<svg aria-label="Cart" />} text="(2)" />);
+
+    const link = screen.getByRole("link", { name: "Cart (2)" });
+
+    expect(link.querySelector(".link-icon")).toBeInTheDocument();
+    expect(link).toHaveTextContent("(2)");
+  });
+});

--- a/frontend/src/components/common/link/link.tsx
+++ b/frontend/src/components/common/link/link.tsx
@@ -1,19 +1,18 @@
-import React from "react";
+import type { ComponentPropsWithoutRef, ReactNode } from "react";
+
 import "./link.scss";
 
-type LinkProps = {
-  text: string; // text label
-  href: string; // URL or path to go to
-  onClick?: (e: React.MouseEvent<HTMLAnchorElement>) => void; // Optional click handler
-  className?: string; // Optional CSS classes
-  icon?: React.ReactNode;
+type LinkProps = Omit<ComponentPropsWithoutRef<"a">, "children" | "href"> & {
+  text: string;
+  href: string;
+  icon?: ReactNode;
 };
 
-const Link: React.FC<LinkProps> = ({ text, href, onClick, className = "", icon }) => {
+const Link = ({ text, href, className = "", icon, ...props }: LinkProps) => {
   const linkClass = `link ${className}`.trim();
 
   return (
-    <a className={linkClass} href={href} onClick={onClick}>
+    <a {...props} className={linkClass} href={href}>
       {icon && <span className="link-icon">{icon}</span>}
       {text}
     </a>

--- a/frontend/src/components/common/message/Message.scss
+++ b/frontend/src/components/common/message/Message.scss
@@ -1,13 +1,30 @@
 .message {
   position: fixed;
-  bottom: 1rem;
+  z-index: 1000;
+  bottom: var(--space-6);
   left: 50%;
+  width: max-content;
+  max-width: calc(100% - var(--space-4) - var(--space-4));
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius-sm);
+  box-shadow: 0 0.4rem 1.2rem rgb(0 0 0 / 15%);
+  color: var(--color-surface);
+  font-family: var(--font-family-body);
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-regular);
+  line-height: var(--line-height-body);
+  text-align: center;
   transform: translateX(-50%);
-  background-color: #22c55e;
-  color: #ffffff;
-  padding: 0.5rem 1rem;
-  border-radius: 0.375rem;
-  box-shadow:
-    0 1px 3px rgba(0, 0, 0, 0.1),
-    0 1px 2px rgba(0, 0, 0, 0.06);
+}
+
+.message--info {
+  background-color: var(--color-ink);
+}
+
+.message--success {
+  background-color: var(--color-success);
+}
+
+.message--error {
+  background-color: var(--color-danger);
 }

--- a/frontend/src/components/common/message/Message.spec.tsx
+++ b/frontend/src/components/common/message/Message.spec.tsx
@@ -1,0 +1,49 @@
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import Message from "./Message";
+
+describe("Message", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("renders a polite success status and closes after the duration", () => {
+    const handleClose = vi.fn();
+
+    render(<Message duration={2000} onClose={handleClose} text="Product removed" />);
+
+    const message = screen.getByRole("status");
+
+    expect(message).toHaveClass("message", "message--success");
+    expect(message).toHaveAttribute("aria-live", "polite");
+    expect(message).toHaveAttribute("aria-atomic", "true");
+
+    act(() => vi.advanceTimersByTime(1999));
+    expect(handleClose).not.toHaveBeenCalled();
+
+    act(() => vi.advanceTimersByTime(1));
+    expect(handleClose).toHaveBeenCalledOnce();
+  });
+
+  it("renders errors as assertive alerts and forwards native attributes", () => {
+    render(
+      <Message className="cart-error" id="cart-error" onClose={vi.fn()} text="Unable to update cart" variant="error" />
+    );
+
+    const message = screen.getByRole("alert");
+
+    expect(message).toHaveClass("message", "message--error", "cart-error");
+    expect(message).toHaveAttribute("aria-live", "assertive");
+    expect(message).toHaveAttribute("id", "cart-error");
+  });
+
+  it("clears the pending timer when it unmounts", () => {
+    const handleClose = vi.fn();
+    const { unmount } = render(<Message onClose={handleClose} text="Saved" />);
+
+    unmount();
+    act(() => vi.runAllTimers());
+
+    expect(handleClose).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/common/message/Message.tsx
+++ b/frontend/src/components/common/message/Message.tsx
@@ -1,17 +1,42 @@
-import { useEffect } from "react";
+import { useEffect, type ComponentPropsWithoutRef } from "react";
+
 import "./Message.scss";
 
-interface MessageProps {
+type MessageVariant = "error" | "info" | "success";
+
+type MessageProps = Omit<ComponentPropsWithoutRef<"div">, "children" | "onClose"> & {
   text: string;
   duration?: number;
   onClose: () => void;
-}
+  variant?: MessageVariant;
+};
 
-export default function Message({ text, duration = 3000, onClose }: MessageProps) {
+export default function Message({
+  text,
+  duration = 3000,
+  onClose,
+  variant = "success",
+  className = "",
+  ...props
+}: MessageProps) {
   useEffect(() => {
     const timer = setTimeout(onClose, duration);
     return () => clearTimeout(timer);
   }, [duration, onClose]);
 
-  return <div className="message">{text}</div>;
+  const messageClass = `message message--${variant} ${className}`.trim();
+  const role = props.role ?? (variant === "error" ? "alert" : "status");
+  const ariaLive = props["aria-live"] ?? (variant === "error" ? "assertive" : "polite");
+
+  return (
+    <div
+      {...props}
+      aria-atomic={props["aria-atomic"] ?? true}
+      aria-live={ariaLive}
+      className={messageClass}
+      role={role}
+    >
+      {text}
+    </div>
+  );
 }

--- a/frontend/src/components/common/paragraph/paragraph.scss
+++ b/frontend/src/components/common/paragraph/paragraph.scss
@@ -1,14 +1,13 @@
 .paragraph {
-  font-family: "Roboto", sans-serif;
-  color: #00000099;
   margin: 0;
-  font-size: 16px;
+  color: var(--color-text-muted);
+  font-family: var(--font-family-body);
+  font-size: var(--font-size-md);
   font-style: normal;
-  font-weight: 400;
-  line-height: 22px;
+  font-weight: var(--font-weight-regular);
+  line-height: var(--line-height-body);
 }
 
-// Error state: red text
 .paragraph--error {
-  color: #e74c3c;
+  color: var(--color-danger);
 }

--- a/frontend/src/components/common/paragraph/paragraph.spec.tsx
+++ b/frontend/src/components/common/paragraph/paragraph.spec.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import Paragraph from "./paragraph";
+
+describe("Paragraph", () => {
+  it("renders text and forwards native paragraph attributes", () => {
+    render(
+      <Paragraph
+        aria-label="Product description"
+        className="product-description"
+        id="description"
+        text="Designed for everyday comfort."
+      />
+    );
+
+    const paragraph = screen.getByLabelText("Product description");
+
+    expect(paragraph.tagName).toBe("P");
+    expect(paragraph).toHaveClass("paragraph", "product-description");
+    expect(paragraph).toHaveAttribute("id", "description");
+    expect(paragraph).toHaveTextContent("Designed for everyday comfort.");
+  });
+
+  it("adds the error class when the paragraph represents an error", () => {
+    render(<Paragraph isError text="Email is required" />);
+
+    expect(screen.getByText("Email is required")).toHaveClass("paragraph", "paragraph--error");
+  });
+});

--- a/frontend/src/components/common/paragraph/paragraph.tsx
+++ b/frontend/src/components/common/paragraph/paragraph.tsx
@@ -1,17 +1,21 @@
-import React from "react";
+import type { ComponentPropsWithoutRef } from "react";
+
 import "./paragraph.scss";
 
-type ParagraphProps = {
-  text: string; // text content
-  isError?: boolean; // Turns text red when true
-  className?: string; // Optional classes for customization
+type ParagraphProps = Omit<ComponentPropsWithoutRef<"p">, "children"> & {
+  text: string;
+  isError?: boolean;
 };
 
-const Paragraph: React.FC<ParagraphProps> = ({ text, isError = false, className = "" }) => {
+const Paragraph = ({ text, isError = false, className = "", ...props }: ParagraphProps) => {
   const errorClass = isError ? "paragraph--error" : "";
   const paragraphClass = `paragraph ${errorClass} ${className}`.trim();
 
-  return <p className={paragraphClass}>{text}</p>;
+  return (
+    <p {...props} className={paragraphClass}>
+      {text}
+    </p>
+  );
 };
 
 export default Paragraph;

--- a/frontend/src/components/common/span/span.scss
+++ b/frontend/src/components/common/span/span.scss
@@ -1,6 +1,12 @@
-.error-message {
-  margin-top: 0.25rem; //placeholder
-  font-size: 0.875rem; //placeholder
+.span {
+  color: inherit;
+  font-family: var(--font-family-body);
+  font-size: var(--font-size-sm);
+  font-style: normal;
+  font-weight: var(--font-weight-regular);
+  line-height: normal;
+}
 
-  color: #e74c3c;
+.span--error {
+  color: var(--color-danger);
 }

--- a/frontend/src/components/common/span/span.spec.tsx
+++ b/frontend/src/components/common/span/span.spec.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import Span from "./span";
+
+describe("Span", () => {
+  it("renders inline text and forwards native span attributes", () => {
+    render(<Span className="announcement-copy" data-testid="announcement" text="Sign up and save 20%" />);
+
+    const span = screen.getByTestId("announcement");
+
+    expect(span.tagName).toBe("SPAN");
+    expect(span).toHaveClass("span", "announcement-copy");
+    expect(span).toHaveTextContent("Sign up and save 20%");
+  });
+
+  it("adds the error class when the inline text represents an error", () => {
+    render(<Span isError text="Invalid promo code" />);
+
+    expect(screen.getByText("Invalid promo code")).toHaveClass("span", "span--error");
+  });
+});

--- a/frontend/src/components/common/span/span.tsx
+++ b/frontend/src/components/common/span/span.tsx
@@ -1,1 +1,21 @@
-// span component here
+import type { ComponentPropsWithoutRef } from "react";
+
+import "./span.scss";
+
+type SpanProps = Omit<ComponentPropsWithoutRef<"span">, "children"> & {
+  text: string;
+  isError?: boolean;
+};
+
+const Span = ({ text, isError = false, className = "", ...props }: SpanProps) => {
+  const errorClass = isError ? "span--error" : "";
+  const spanClass = `span ${errorClass} ${className}`.trim();
+
+  return (
+    <span {...props} className={spanClass}>
+      {text}
+    </span>
+  );
+};
+
+export default Span;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,6 +2,9 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
 
+import "@fontsource/roboto/latin-400.css";
+import "@fontsource/roboto/latin-500.css";
+import "@fontsource/roboto/latin-700.css";
 import "./assets/styles/global.scss";
 
 createRoot(document.getElementById("root")!).render(

--- a/package-lock.json
+++ b/package-lock.json
@@ -468,6 +468,7 @@
       "name": "@sport-gear/frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@fontsource/roboto": "^5.3.0",
         "axios": "^1.18.1",
         "react": "19.1.0",
         "react-dom": "19.1.0",
@@ -1500,6 +1501,15 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@fontsource/roboto": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource/roboto/-/roboto-5.3.0.tgz",
+      "integrity": "sha512-BapRJOWYP+LZ21zp+wBQjfpPYKRoxc4LspJ/RLuI+HSMBD5u/X4O+ESDrSvEqDSy0rAl7GwBJ+09mdc16cVQ1Q==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@hono/node-server": {
@@ -2571,7 +2581,6 @@
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "detect-libc": "^1.0.3",
         "is-glob": "^4.0.3",
@@ -2614,7 +2623,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -2636,7 +2644,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -2658,7 +2665,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -2680,7 +2686,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -2702,7 +2707,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -2724,7 +2728,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -2746,7 +2749,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -2768,7 +2770,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -2790,7 +2791,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -2812,7 +2812,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -2834,7 +2833,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -2856,7 +2854,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -2878,7 +2875,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -3757,7 +3753,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -3775,7 +3770,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -3793,7 +3787,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -3811,7 +3804,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -3829,7 +3821,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -3847,7 +3838,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -3865,7 +3855,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -3883,7 +3872,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -3901,7 +3889,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -3919,7 +3906,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -4331,7 +4317,7 @@
       "version": "19.1.2",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.2.tgz",
       "integrity": "sha512-XGJkWF41Qq305SKWEILa1O8vzhb3aOo3ogBlSmiqNko/WmRb6QIaweuZCXjKygVDXpzXb5wyxKTSOsmkuqj+Qw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
@@ -6454,7 +6440,6 @@
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "bin": {
         "detect-libc": "bin/detect-libc.js"
       },
@@ -9296,8 +9281,7 @@
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/node-emoji": {
       "version": "1.11.0",
@@ -13081,24 +13065,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {


### PR DESCRIPTION
## Summary

- add a reusable storefront design-token foundation for colors, typography, spacing, radii, shadows, and responsive breakpoints
- bundle Roboto through `@fontsource` and add a responsive `PageContainer`
- align `Button`, `InputField`, headings, `Paragraph`, `Link`, and `Message` with the new visual system
- add the `Span` typography primitive and an accessible `IconButton`

## Why

This establishes the shared UI foundation required to implement the remaining Figma storefront screens consistently. Keeping these primitives in a dedicated feature PR makes later page-level changes smaller and easier to review.

## Impact

- no backend or public API changes
- no storefront page migration yet
- existing shared components keep their current external behavior while gaining consistent styling and accessibility improvements

## Validation

- `npm run test --workspace frontend` — 19 tests passed
- `npm run lint --workspace frontend` — passed
- `npm run build --workspace frontend` — passed
- repository pre-commit format and lint checks — passed

## Follow-up

Subsequent feature branches can build individual layout sections and pages on top of these primitives, with one completed feature per PR into `develop`.