### PR TITLE
feat(storefront): add responsive footer and newsletter subscriptions

### DIFF
--- a/backend/prisma/migrations/20260806211500_add_newsletter_subscriptions/migration.sql
+++ b/backend/prisma/migrations/20260806211500_add_newsletter_subscriptions/migration.sql
@@ -1,0 +1,9 @@
+CREATE TABLE "NewsletterSubscription" (
+  "id" UUID NOT NULL,
+  "email" TEXT NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "NewsletterSubscription_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "NewsletterSubscription_email_key" ON "NewsletterSubscription"("email");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -48,6 +48,7 @@ model Address {
   isDefaultBilling  Boolean  @default(false)
   createdAt         DateTime @default(now())
   updatedAt         DateTime @updatedAt
+
   @@index([userId])
 }
 
@@ -61,6 +62,7 @@ model RefreshSession {
   userAgent String?
   ipAddress String?
   createdAt DateTime  @default(now())
+
   @@index([userId])
 }
 
@@ -75,6 +77,7 @@ model Category {
   products  ProductCategory[]
   createdAt DateTime          @default(now())
   updatedAt DateTime          @updatedAt
+
   @@unique([parentId, slug])
   @@index([parentId])
 }
@@ -113,6 +116,7 @@ model ProductImage {
   url       String
   alt       String
   sortOrder Int     @default(0)
+
   @@index([productId, sortOrder])
 }
 
@@ -121,6 +125,7 @@ model ProductCategory {
   categoryId String   @db.Uuid
   product    Product  @relation(fields: [productId], references: [id], onDelete: Cascade)
   category   Category @relation(fields: [categoryId], references: [id], onDelete: Cascade)
+
   @@id([productId, categoryId])
   @@index([categoryId])
 }
@@ -154,6 +159,7 @@ model Cart {
   items          CartItem[]
   createdAt      DateTime      @default(now())
   updatedAt      DateTime      @updatedAt
+
   @@index([status])
 }
 
@@ -166,6 +172,14 @@ model CartItem {
   quantity  Int
   createdAt DateTime       @default(now())
   updatedAt DateTime       @updatedAt
+
   @@unique([cartId, variantId])
   @@index([cartId])
+}
+
+model NewsletterSubscription {
+  id        String   @id @default(uuid()) @db.Uuid
+  email     String   @unique
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 }

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -7,6 +7,7 @@ import { CatalogModule } from "./catalog/catalog.module.js";
 import { validateConfig } from "./config/configuration.js";
 import { DatabaseModule } from "./database/database.module.js";
 import { HealthModule } from "./health/health.module.js";
+import { NewsletterModule } from "./newsletter/newsletter.module.js";
 import { PromotionsModule } from "./promotions/promotions.module.js";
 import { SecurityModule } from "./security/security.module.js";
 import { UsersModule } from "./users/users.module.js";
@@ -18,6 +19,7 @@ import { UsersModule } from "./users/users.module.js";
     DatabaseModule,
     SecurityModule,
     HealthModule,
+    NewsletterModule,
     UsersModule,
     CatalogModule,
     PromotionsModule,

--- a/backend/src/newsletter/dto/newsletter-subscription.dto.spec.ts
+++ b/backend/src/newsletter/dto/newsletter-subscription.dto.spec.ts
@@ -1,0 +1,22 @@
+import "reflect-metadata";
+
+import { plainToInstance } from "class-transformer";
+import { validate } from "class-validator";
+import { describe, expect, it } from "vitest";
+
+import { CreateNewsletterSubscriptionDto } from "./newsletter-subscription.dto.js";
+
+describe("CreateNewsletterSubscriptionDto", () => {
+  it("normalizes a valid email", async () => {
+    const input = plainToInstance(CreateNewsletterSubscriptionDto, { email: "  SHOPPER@Example.com  " });
+
+    expect(input.email).toBe("shopper@example.com");
+    expect(await validate(input)).toHaveLength(0);
+  });
+
+  it("rejects invalid email addresses", async () => {
+    const input = plainToInstance(CreateNewsletterSubscriptionDto, { email: "not-an-email" });
+
+    expect(await validate(input)).not.toHaveLength(0);
+  });
+});

--- a/backend/src/newsletter/dto/newsletter-subscription.dto.ts
+++ b/backend/src/newsletter/dto/newsletter-subscription.dto.ts
@@ -1,0 +1,19 @@
+import { Transform } from "class-transformer";
+import { IsEmail, MaxLength } from "class-validator";
+import { ApiProperty } from "@nestjs/swagger";
+
+export class CreateNewsletterSubscriptionDto {
+  @ApiProperty({ example: "shopper@example.com", maxLength: 254 })
+  @Transform(({ value }) => (typeof value === "string" ? value.trim().toLowerCase() : value))
+  @IsEmail()
+  @MaxLength(254)
+  email!: string;
+}
+
+export class NewsletterSubscriptionDto {
+  @ApiProperty({ example: "shopper@example.com" })
+  email!: string;
+
+  @ApiProperty({ format: "date-time" })
+  subscribedAt!: string;
+}

--- a/backend/src/newsletter/newsletter.controller.ts
+++ b/backend/src/newsletter/newsletter.controller.ts
@@ -1,0 +1,20 @@
+import { Body, Controller, HttpCode, HttpStatus, Post } from "@nestjs/common";
+import { ApiCreatedResponse, ApiTags } from "@nestjs/swagger";
+import { Throttle } from "@nestjs/throttler";
+
+import { CreateNewsletterSubscriptionDto, NewsletterSubscriptionDto } from "./dto/newsletter-subscription.dto.js";
+import { NewsletterService } from "./newsletter.service.js";
+
+@Controller("newsletter")
+@ApiTags("newsletter")
+export class NewsletterController {
+  constructor(private readonly newsletter: NewsletterService) {}
+
+  @Post("subscriptions")
+  @HttpCode(HttpStatus.CREATED)
+  @Throttle({ default: { limit: 5, ttl: 60_000 } })
+  @ApiCreatedResponse({ type: NewsletterSubscriptionDto })
+  subscribe(@Body() input: CreateNewsletterSubscriptionDto) {
+    return this.newsletter.subscribe(input.email);
+  }
+}

--- a/backend/src/newsletter/newsletter.module.ts
+++ b/backend/src/newsletter/newsletter.module.ts
@@ -1,0 +1,7 @@
+import { Module } from "@nestjs/common";
+
+import { NewsletterController } from "./newsletter.controller.js";
+import { NewsletterService } from "./newsletter.service.js";
+
+@Module({ controllers: [NewsletterController], providers: [NewsletterService] })
+export class NewsletterModule {}

--- a/backend/src/newsletter/newsletter.service.spec.ts
+++ b/backend/src/newsletter/newsletter.service.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { NewsletterService } from "./newsletter.service.js";
+
+describe("NewsletterService", () => {
+  it("upserts a normalized subscription and returns its original subscription date", async () => {
+    const createdAt = new Date("2026-08-06T18:00:00.000Z");
+    const prisma = {
+      newsletterSubscription: {
+        upsert: vi.fn().mockResolvedValue({ email: "shopper@example.com", createdAt }),
+      },
+    };
+
+    const result = await new NewsletterService(prisma as never).subscribe("  SHOPPER@Example.com ");
+
+    expect(prisma.newsletterSubscription.upsert).toHaveBeenCalledWith({
+      where: { email: "shopper@example.com" },
+      update: {},
+      create: { email: "shopper@example.com" },
+      select: { email: true, createdAt: true },
+    });
+    expect(result).toEqual({
+      email: "shopper@example.com",
+      subscribedAt: "2026-08-06T18:00:00.000Z",
+    });
+  });
+});

--- a/backend/src/newsletter/newsletter.service.ts
+++ b/backend/src/newsletter/newsletter.service.ts
@@ -1,0 +1,23 @@
+import { Injectable } from "@nestjs/common";
+
+import { PrismaService } from "../database/prisma.service.js";
+
+@Injectable()
+export class NewsletterService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async subscribe(email: string) {
+    const normalizedEmail = email.trim().toLowerCase();
+    const subscription = await this.prisma.newsletterSubscription.upsert({
+      where: { email: normalizedEmail },
+      update: {},
+      create: { email: normalizedEmail },
+      select: { email: true, createdAt: true },
+    });
+
+    return {
+      email: subscription.email,
+      subscribedAt: subscription.createdAt.toISOString(),
+    };
+  }
+}

--- a/frontend/src/components/Footer/Footer.scss
+++ b/frontend/src/components/Footer/Footer.scss
@@ -1,33 +1,112 @@
-.footer {
-  margin-top: 100px;
-  padding: 10px;
+@use "../../assets/styles/tokens" as *;
 
-  &__content {
-    display: flex;
-    justify-content: space-around;
-    align-items: center;
-    gap: 10px;
+.site-footer {
+  margin-top: 18rem;
+  background: var(--color-surface-subtle);
+}
+
+.site-footer__container {
+  padding-bottom: var(--space-20);
+}
+
+.site-footer__newsletter {
+  margin-bottom: -4rem;
+  transform: translateY(-50%);
+}
+
+.site-footer__content {
+  display: grid;
+  padding-bottom: var(--space-12);
+  align-items: start;
+  gap: var(--space-16);
+  grid-template-columns: minmax(24rem, 1.1fr) 3fr;
+}
+
+.site-footer__brand {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-6);
+}
+
+.site-footer__description {
+  max-width: 28rem;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-relaxed);
+}
+
+.site-footer__navigation {
+  display: grid;
+  gap: var(--space-8);
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.site-footer__bottom {
+  display: flex;
+  padding-top: var(--space-5);
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-5);
+  border-top: var(--border-subtle);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+}
+
+.site-footer__demo-note {
+  text-align: end;
+}
+
+@media (max-width: $breakpoint-tablet) {
+  .site-footer__content {
+    gap: var(--space-10);
+    grid-template-columns: 1fr;
   }
 
-  &__logo {
-    width: 50px;
-    height: auto;
-    transition: transform 0.3s ease;
+  .site-footer__navigation {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}
 
-    &.rs {
-      width: 70px;
-    }
-
-    &:hover {
-      transform: scale(1.05);
-    }
+@media (max-width: $breakpoint-mobile) {
+  .site-footer {
+    margin-top: 20rem;
   }
 
-  &__logo-link {
-    display: inline-block;
+  .site-footer__container {
+    padding-bottom: var(--space-10);
   }
 
-  &__year {
-    font-size: 1.5rem;
+  .site-footer__newsletter {
+    margin-bottom: -9rem;
+  }
+
+  .site-footer__content {
+    padding-bottom: var(--space-10);
+  }
+
+  .site-footer__brand {
+    gap: var(--space-5);
+  }
+
+  .site-footer__description {
+    max-width: 34rem;
+  }
+
+  .site-footer__navigation {
+    column-gap: var(--space-6);
+    row-gap: var(--space-10);
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .site-footer__bottom {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--space-2);
+  }
+
+  .site-footer__demo-note {
+    text-align: start;
   }
 }

--- a/frontend/src/components/Footer/Footer.spec.tsx
+++ b/frontend/src/components/Footer/Footer.spec.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+
+import Footer from "./Footer";
+
+describe("Footer", () => {
+  it("renders the newsletter, real navigation and project information", () => {
+    render(
+      <MemoryRouter>
+        <Footer />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole("heading", { name: "STAY UP TO DATE ABOUT OUR LATEST OFFERS" })).toBeInTheDocument();
+    expect(screen.getByRole("navigation", { name: "Company" })).toBeInTheDocument();
+    expect(screen.getByRole("navigation", { name: "Shop" })).toBeInTheDocument();
+    expect(screen.getByRole("navigation", { name: "Account" })).toBeInTheDocument();
+    expect(screen.getByRole("navigation", { name: "Resources" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Sport Gear home" })).toHaveAttribute("href", "/");
+    expect(screen.getByText("Demo store · Payments are not processed")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/Footer/Footer.tsx
+++ b/frontend/src/components/Footer/Footer.tsx
@@ -1,19 +1,86 @@
+import { PageContainer } from "../common/PageContainer/PageContainer";
+import { StoreLogo } from "../common/StoreLogo/StoreLogo";
+
+import FooterLinkColumn, { type FooterLinkItem } from "./FooterLinkColumn/FooterLinkColumn";
+import FooterProjectLinks from "./FooterProjectLinks/FooterProjectLinks";
+import NewsletterSignup from "./NewsletterSignup/NewsletterSignup";
 import "./Footer.scss";
 
+type FooterNavigationGroup = {
+  title: string;
+  links: FooterLinkItem[];
+};
+
+const footerNavigation: FooterNavigationGroup[] = [
+  {
+    title: "Company",
+    links: [
+      { href: "/", label: "Home" },
+      { href: "/about", label: "About" },
+    ],
+  },
+  {
+    title: "Shop",
+    links: [
+      { href: "/catalog", label: "Catalog" },
+      { href: "/basket", label: "Basket" },
+    ],
+  },
+  {
+    title: "Account",
+    links: [
+      { href: "/profile", label: "Profile" },
+      { href: "/login", label: "Sign in" },
+      { href: "/sign-up", label: "Create account" },
+    ],
+  },
+  {
+    title: "Resources",
+    links: [
+      {
+        external: true,
+        href: "https://github.com/Ryhus/eCommerce-group-project",
+        label: "Source code",
+      },
+      {
+        external: true,
+        href: "https://www.figma.com/design/5YOFNziZ7GHoRl7tgAo3ii/E-commerce-Website-Template--Freebie---Community-",
+        label: "Design reference",
+      },
+      { external: true, href: "https://rs.school/", label: "RS School" },
+    ],
+  },
+];
+
 const Footer = () => {
+  const currentYear = new Date().getFullYear();
+
   return (
-    <footer className="footer">
-      <div className="footer__content">
-        <a href="https://rs.school/" target="_blank" rel="noopener noreferrer" className="footer__logo-link">
-          <img src="/logos/rs-school-logo.svg" alt="RS School Logo" className="footer__logo rs" />
-        </a>
+    <footer className="site-footer">
+      <PageContainer className="site-footer__container">
+        <NewsletterSignup className="site-footer__newsletter" />
 
-        <p className="footer__year">© 2025</p>
+        <div className="site-footer__content">
+          <div className="site-footer__brand">
+            <StoreLogo />
+            <p className="site-footer__description">
+              Performance-ready sportswear and equipment for training, competition, and everyday movement.
+            </p>
+            <FooterProjectLinks />
+          </div>
 
-        <a href="https://github.com/ryhus" target="_blank" rel="noopener noreferrer" className="footer__logo-link">
-          <img src="/logos/gh-logo.png" alt="Github Logo" className="footer__logo gh" />
-        </a>
-      </div>
+          <div className="site-footer__navigation">
+            {footerNavigation.map((group) => (
+              <FooterLinkColumn key={group.title} links={group.links} title={group.title} />
+            ))}
+          </div>
+        </div>
+
+        <div className="site-footer__bottom">
+          <p>Sport Gear © {currentYear}. All rights reserved.</p>
+          <p className="site-footer__demo-note">Demo store · Payments are not processed</p>
+        </div>
+      </PageContainer>
     </footer>
   );
 };

--- a/frontend/src/components/Footer/FooterLinkColumn/FooterLinkColumn.scss
+++ b/frontend/src/components/Footer/FooterLinkColumn/FooterLinkColumn.scss
@@ -1,0 +1,38 @@
+.footer-link-column {
+  min-width: 0;
+}
+
+.footer-link-column__title {
+  margin: 0 0 var(--space-6);
+  color: var(--color-ink);
+  font-family: var(--font-family-body);
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-medium);
+  letter-spacing: 0.3rem;
+  line-height: var(--line-height-body);
+  text-transform: uppercase;
+}
+
+.footer-link-column__list {
+  display: flex;
+  margin: 0;
+  padding: 0;
+  flex-direction: column;
+  gap: var(--space-4);
+  list-style: none;
+}
+
+.footer-link-column__link {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-md);
+  line-height: var(--line-height-relaxed);
+  text-decoration: none;
+  transition: color var(--transition-fast);
+
+  &:hover,
+  &:focus-visible {
+    color: var(--color-ink);
+    text-decoration: underline;
+    text-underline-offset: 0.3rem;
+  }
+}

--- a/frontend/src/components/Footer/FooterLinkColumn/FooterLinkColumn.spec.tsx
+++ b/frontend/src/components/Footer/FooterLinkColumn/FooterLinkColumn.spec.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+
+import FooterLinkColumn from "./FooterLinkColumn";
+
+describe("FooterLinkColumn", () => {
+  it("renders an accessible navigation group with internal links", () => {
+    render(
+      <MemoryRouter>
+        <FooterLinkColumn
+          links={[
+            { href: "/catalog", label: "Catalog" },
+            { href: "/basket", label: "Basket" },
+          ]}
+          title="Shop"
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole("navigation", { name: "Shop" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Catalog" })).toHaveAttribute("href", "/catalog");
+    expect(screen.getByRole("link", { name: "Basket" })).not.toHaveAttribute("target");
+  });
+
+  it("opens external links without exposing the originating page", () => {
+    render(
+      <MemoryRouter>
+        <FooterLinkColumn
+          links={[{ external: true, href: "https://github.com/example/project", label: "Source code" }]}
+          title="Resources"
+        />
+      </MemoryRouter>
+    );
+
+    const link = screen.getByRole("link", { name: "Source code" });
+
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+});

--- a/frontend/src/components/Footer/FooterLinkColumn/FooterLinkColumn.tsx
+++ b/frontend/src/components/Footer/FooterLinkColumn/FooterLinkColumn.tsx
@@ -1,0 +1,45 @@
+import { useId, type ComponentPropsWithoutRef } from "react";
+import { Link } from "react-router-dom";
+
+import "./FooterLinkColumn.scss";
+
+export type FooterLinkItem = {
+  label: string;
+  href: string;
+  external?: boolean;
+};
+
+type FooterLinkColumnProps = Omit<ComponentPropsWithoutRef<"nav">, "children"> & {
+  title: string;
+  links: FooterLinkItem[];
+};
+
+const FooterLinkColumn = ({ title, links, className = "", ...props }: FooterLinkColumnProps) => {
+  const titleId = useId();
+  const navClassName = `footer-link-column ${className}`.trim();
+
+  return (
+    <nav {...props} aria-labelledby={titleId} className={navClassName}>
+      <h2 className="footer-link-column__title" id={titleId}>
+        {title}
+      </h2>
+      <ul className="footer-link-column__list">
+        {links.map(({ label, href, external }) => (
+          <li key={`${label}-${href}`}>
+            {external ? (
+              <a className="footer-link-column__link" href={href} rel="noopener noreferrer" target="_blank">
+                {label}
+              </a>
+            ) : (
+              <Link className="footer-link-column__link" to={href}>
+                {label}
+              </Link>
+            )}
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+};
+
+export default FooterLinkColumn;

--- a/frontend/src/components/Footer/FooterProjectLinks/FooterProjectLinks.scss
+++ b/frontend/src/components/Footer/FooterProjectLinks/FooterProjectLinks.scss
@@ -1,0 +1,36 @@
+.footer-project-links {
+  display: flex;
+  margin: 0;
+  padding: 0;
+  align-items: center;
+  gap: var(--space-3);
+  list-style: none;
+}
+
+.footer-project-links__link {
+  display: inline-flex;
+  width: 2.8rem;
+  height: 2.8rem;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--color-border);
+  border-radius: 50%;
+  background: var(--color-surface);
+  color: var(--color-ink);
+  transition:
+    background-color var(--transition-fast),
+    color var(--transition-fast),
+    transform var(--transition-fast);
+
+  svg {
+    width: 1.6rem;
+    height: 1.6rem;
+  }
+
+  &:hover,
+  &:focus-visible {
+    background: var(--color-ink);
+    color: var(--color-surface);
+    transform: translateY(-0.2rem);
+  }
+}

--- a/frontend/src/components/Footer/FooterProjectLinks/FooterProjectLinks.spec.tsx
+++ b/frontend/src/components/Footer/FooterProjectLinks/FooterProjectLinks.spec.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import FooterProjectLinks from "./FooterProjectLinks";
+
+describe("FooterProjectLinks", () => {
+  it("renders the real project resources as accessible external links", () => {
+    render(<FooterProjectLinks />);
+
+    expect(screen.getByRole("list", { name: "Project links" })).toBeInTheDocument();
+
+    const links = screen.getAllByRole("link");
+
+    expect(links).toHaveLength(3);
+    expect(screen.getByRole("link", { name: "Sport Gear source code on GitHub" })).toHaveAttribute(
+      "href",
+      "https://github.com/Ryhus/eCommerce-group-project"
+    );
+
+    links.forEach((link) => {
+      expect(link).toHaveAttribute("target", "_blank");
+      expect(link).toHaveAttribute("rel", "noopener noreferrer");
+    });
+  });
+});

--- a/frontend/src/components/Footer/FooterProjectLinks/FooterProjectLinks.tsx
+++ b/frontend/src/components/Footer/FooterProjectLinks/FooterProjectLinks.tsx
@@ -1,0 +1,55 @@
+import type { ComponentPropsWithoutRef, ReactNode } from "react";
+import { FaFigma, FaGithub } from "react-icons/fa";
+import { IoSchoolOutline } from "react-icons/io5";
+
+import "./FooterProjectLinks.scss";
+
+type ProjectLink = {
+  href: string;
+  icon: ReactNode;
+  label: string;
+};
+
+const projectLinks: ProjectLink[] = [
+  {
+    href: "https://github.com/Ryhus/eCommerce-group-project",
+    icon: <FaGithub />,
+    label: "Sport Gear source code on GitHub",
+  },
+  {
+    href: "https://www.figma.com/design/5YOFNziZ7GHoRl7tgAo3ii/E-commerce-Website-Template--Freebie---Community-",
+    icon: <FaFigma />,
+    label: "Original storefront design in Figma",
+  },
+  {
+    href: "https://rs.school/",
+    icon: <IoSchoolOutline />,
+    label: "RS School website",
+  },
+];
+
+type FooterProjectLinksProps = Omit<ComponentPropsWithoutRef<"ul">, "children">;
+
+const FooterProjectLinks = ({ className = "", ...props }: FooterProjectLinksProps) => {
+  const listClassName = `footer-project-links ${className}`.trim();
+
+  return (
+    <ul {...props} aria-label="Project links" className={listClassName}>
+      {projectLinks.map(({ href, icon, label }) => (
+        <li key={href}>
+          <a
+            aria-label={label}
+            className="footer-project-links__link"
+            href={href}
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            {icon}
+          </a>
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default FooterProjectLinks;

--- a/frontend/src/components/Footer/NewsletterSignup/NewsletterSignup.scss
+++ b/frontend/src/components/Footer/NewsletterSignup/NewsletterSignup.scss
@@ -1,0 +1,63 @@
+@use "../../../assets/styles/tokens" as *;
+
+.newsletter-signup {
+  display: flex;
+  min-height: 18rem;
+  padding: 3.6rem var(--space-16);
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-10);
+  border-radius: var(--radius-md);
+  background: var(--color-ink);
+  color: var(--color-surface);
+}
+
+.newsletter-signup__heading {
+  max-width: 55rem;
+  color: inherit;
+  font-size: var(--font-size-3xl);
+  line-height: var(--line-height-heading);
+}
+
+.newsletter-signup__form {
+  display: flex;
+  width: min(100%, 35rem);
+  flex: 0 0 35rem;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.newsletter-signup__input .input {
+  min-height: 4.8rem;
+  background: var(--color-surface);
+}
+
+.newsletter-signup__button {
+  max-width: none;
+}
+
+@media (max-width: $breakpoint-tablet) {
+  .newsletter-signup {
+    padding-inline: var(--space-8);
+  }
+}
+
+@media (max-width: $breakpoint-mobile) {
+  .newsletter-signup {
+    min-height: 29rem;
+    padding: var(--space-8) var(--space-6);
+    align-items: stretch;
+    flex-direction: column;
+    gap: var(--space-8);
+  }
+
+  .newsletter-signup__heading {
+    max-width: none;
+    font-size: var(--font-size-2xl);
+  }
+
+  .newsletter-signup__form {
+    width: 100%;
+    flex-basis: auto;
+  }
+}

--- a/frontend/src/components/Footer/NewsletterSignup/NewsletterSignup.spec.tsx
+++ b/frontend/src/components/Footer/NewsletterSignup/NewsletterSignup.spec.tsx
@@ -1,0 +1,59 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { subscribeToNewsletter } from "../../../services/newsletterService/newsletterService";
+
+import NewsletterSignup from "./NewsletterSignup";
+
+vi.mock("../../../services/newsletterService/newsletterService", () => ({
+  subscribeToNewsletter: vi.fn(),
+}));
+
+const subscribeMock = vi.mocked(subscribeToNewsletter);
+
+describe("NewsletterSignup", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("normalizes and submits a valid email address", async () => {
+    subscribeMock.mockResolvedValue({
+      email: "shopper@example.com",
+      subscribedAt: "2026-08-06T20:00:00.000Z",
+    });
+    render(<NewsletterSignup />);
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Email address" }), {
+      target: { value: "  Shopper@Example.com  " },
+    });
+    fireEvent.submit(screen.getByRole("form", { name: "Newsletter subscription" }));
+
+    await waitFor(() => expect(subscribeMock).toHaveBeenCalledWith("shopper@example.com"));
+    expect(await screen.findByRole("status")).toHaveTextContent("You're subscribed");
+    expect(screen.getByRole("textbox", { name: "Email address" })).toHaveValue("");
+  });
+
+  it("shows validation feedback without calling the API", () => {
+    render(<NewsletterSignup />);
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Email address" }), {
+      target: { value: "not-an-email" },
+    });
+    fireEvent.submit(screen.getByRole("form", { name: "Newsletter subscription" }));
+
+    expect(screen.getByRole("alert")).toHaveTextContent("must contain an '@' symbol");
+    expect(subscribeMock).not.toHaveBeenCalled();
+  });
+
+  it("shows an error when the subscription request fails", async () => {
+    subscribeMock.mockRejectedValue(new Error("Network error"));
+    render(<NewsletterSignup />);
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Email address" }), {
+      target: { value: "shopper@example.com" },
+    });
+    fireEvent.submit(screen.getByRole("form", { name: "Newsletter subscription" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Unable to subscribe right now");
+  });
+});

--- a/frontend/src/components/Footer/NewsletterSignup/NewsletterSignup.tsx
+++ b/frontend/src/components/Footer/NewsletterSignup/NewsletterSignup.tsx
@@ -1,0 +1,94 @@
+import { useState, type ComponentPropsWithoutRef, type FormEvent } from "react";
+import { MdOutlineEmail } from "react-icons/md";
+
+import { subscribeToNewsletter } from "../../../services/newsletterService/newsletterService";
+import { validateEmailFormat } from "../../../utils/validation";
+import Button from "../../common/button/button";
+import { H2 } from "../../common/headings/H2";
+import InputField from "../../common/inputField/inputField";
+import Message from "../../common/message/Message";
+
+import "./NewsletterSignup.scss";
+
+type NewsletterSignupProps = Omit<ComponentPropsWithoutRef<"section">, "children">;
+
+type Feedback = {
+  text: string;
+  variant: "error" | "success";
+};
+
+const NewsletterSignup = ({ className = "", ...props }: NewsletterSignupProps) => {
+  const [email, setEmail] = useState("");
+  const [emailError, setEmailError] = useState<string | null>(null);
+  const [feedback, setFeedback] = useState<Feedback | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleEmailChange = (value: string) => {
+    setEmail(value);
+    setEmailError(null);
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const normalizedEmail = email.trim().toLowerCase();
+    const validationError = validateEmailFormat(normalizedEmail);
+
+    if (validationError) {
+      setEmailError(validationError);
+      setFeedback({ text: validationError, variant: "error" });
+      return;
+    }
+
+    setIsSubmitting(true);
+    setFeedback(null);
+
+    try {
+      await subscribeToNewsletter(normalizedEmail);
+      setEmail("");
+      setFeedback({ text: "You're subscribed to Sport Gear updates.", variant: "success" });
+    } catch {
+      setFeedback({ text: "Unable to subscribe right now. Please try again.", variant: "error" });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const sectionClassName = `newsletter-signup ${className}`.trim();
+
+  return (
+    <section {...props} className={sectionClassName}>
+      <H2 className="newsletter-signup__heading" text="STAY UP TO DATE ABOUT OUR LATEST OFFERS" />
+
+      <form aria-label="Newsletter subscription" className="newsletter-signup__form" onSubmit={handleSubmit} noValidate>
+        <InputField
+          aria-label="Email address"
+          autoComplete="email"
+          disabled={isSubmitting}
+          icon={<MdOutlineEmail />}
+          inputMode="email"
+          isValid={!emailError}
+          maxLength={254}
+          name="email"
+          onChange={handleEmailChange}
+          placeholder="Enter your email address"
+          required
+          type="email"
+          value={email}
+          wrapperClassName="newsletter-signup__input"
+        />
+        <Button
+          className="btn-medium newsletter-signup__button"
+          disabled={isSubmitting}
+          text={isSubmitting ? "Subscribing..." : "Subscribe to Newsletter"}
+          type="submit"
+          variant="light"
+        />
+      </form>
+
+      {feedback && <Message onClose={() => setFeedback(null)} text={feedback.text} variant={feedback.variant} />}
+    </section>
+  );
+};
+
+export default NewsletterSignup;

--- a/frontend/src/layouts/MainLayout.scss
+++ b/frontend/src/layouts/MainLayout.scss
@@ -1,0 +1,11 @@
+.app-shell {
+  display: flex;
+  min-height: 100%;
+  flex-direction: column;
+}
+
+.app-shell__main {
+  display: flex;
+  flex: 1 0 auto;
+  flex-direction: column;
+}

--- a/frontend/src/layouts/MainLayout.tsx
+++ b/frontend/src/layouts/MainLayout.tsx
@@ -5,14 +5,16 @@ import Footer from "../components/Footer/Footer";
 import { CartDataProvider } from "../components/context/CartContextProvider";
 import { AuthProvider } from "../components/context/AuthContextProvider";
 
+import "./MainLayout.scss";
+
 function MainLayout() {
   return (
-    <div>
+    <div className="app-shell">
       <AnnouncementBar />
       <AuthProvider>
         <CartDataProvider>
           <Header />
-          <main>
+          <main className="app-shell__main">
             <Outlet />
           </main>
         </CartDataProvider>

--- a/frontend/src/services/newsletterService/newsletterService.spec.ts
+++ b/frontend/src/services/newsletterService/newsletterService.spec.ts
@@ -1,0 +1,25 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { apiClient } from "../apiClient";
+import { subscribeToNewsletter } from "./newsletterService";
+
+vi.mock("../apiClient", () => ({
+  apiClient: { post: vi.fn() },
+}));
+
+describe("newsletterService", () => {
+  beforeEach(() => vi.mocked(apiClient.post).mockReset());
+
+  it("subscribes an email through the newsletter API", async () => {
+    const subscription = {
+      email: "shopper@example.com",
+      subscribedAt: "2026-08-06T18:00:00.000Z",
+    };
+    vi.mocked(apiClient.post).mockResolvedValue({ data: subscription });
+
+    await expect(subscribeToNewsletter("shopper@example.com")).resolves.toEqual(subscription);
+    expect(apiClient.post).toHaveBeenCalledWith("/newsletter/subscriptions", {
+      email: "shopper@example.com",
+    });
+  });
+});

--- a/frontend/src/services/newsletterService/newsletterService.ts
+++ b/frontend/src/services/newsletterService/newsletterService.ts
@@ -1,0 +1,11 @@
+import { apiClient } from "../apiClient";
+
+export interface NewsletterSubscription {
+  email: string;
+  subscribedAt: string;
+}
+
+export async function subscribeToNewsletter(email: string): Promise<NewsletterSubscription> {
+  const response = await apiClient.post<NewsletterSubscription>("/newsletter/subscriptions", { email });
+  return response.data;
+}


### PR DESCRIPTION
## Summary

Adds the responsive storefront footer and makes its newsletter form functional end to end.

## What changed

### Backend
- added the `NewsletterSubscription` Prisma model and PostgreSQL migration
- added an idempotent `POST /api/v1/newsletter/subscriptions` endpoint
- normalized and validated subscriber email addresses
- rate-limited subscription requests
- added DTO and service unit tests

### Frontend
- added a typed newsletter API service
- added an accessible newsletter signup form with validation, loading, success, and error states
- added reusable footer navigation and project-link components
- replaced the temporary footer with a responsive storefront footer
- added an app-shell layout so the footer stays at the bottom of short pages
- used only routes and external resources that actually exist
- explicitly identifies the project as a demo instead of showing unsupported payment methods

## Validation

- `npm run format:check`
- `npm run lint`
- frontend: 41 tests passed
- backend: 16 tests passed
- frontend and backend production builds
- `prisma validate`
- `prisma generate`
- desktop and 390 px mobile visual QA
