### PR TITLE
feat(storefront): redesign responsive catalog

### DIFF
--- a/backend/src/catalog/catalog.service.spec.ts
+++ b/backend/src/catalog/catalog.service.spec.ts
@@ -70,4 +70,33 @@ describe("CatalogService", () => {
     expect(transaction.product.findMany).toHaveBeenCalledWith(expect.objectContaining({ where }));
     expect(transaction.product.count).toHaveBeenCalledWith({ where });
   });
+
+  it("includes descendant categories when filtering by a parent category", async () => {
+    const transaction = {
+      category: {
+        findMany: vi.fn().mockResolvedValue([
+          { id: "balls", parentId: null },
+          { id: "football", parentId: "balls" },
+          { id: "youth-football", parentId: "football" },
+          { id: "fitness", parentId: null },
+        ]),
+      },
+      product: {
+        findMany: vi.fn().mockResolvedValue([]),
+        count: vi.fn().mockResolvedValue(0),
+      },
+    };
+    const prisma = {
+      $transaction: vi.fn(async (callback: (tx: typeof transaction) => Promise<unknown>) => callback(transaction)),
+    };
+    const query = Object.assign(new ProductQueryDto(), { categoryId: "balls" });
+
+    await new CatalogService(prisma as never).products(query);
+
+    const where = expect.objectContaining({
+      categories: { some: { categoryId: { in: ["balls", "football", "youth-football"] } } },
+    });
+    expect(transaction.product.findMany).toHaveBeenCalledWith(expect.objectContaining({ where }));
+    expect(transaction.product.count).toHaveBeenCalledWith({ where });
+  });
 });

--- a/backend/src/catalog/catalog.service.ts
+++ b/backend/src/catalog/catalog.service.ts
@@ -36,10 +36,9 @@ export class CatalogService {
   }
 
   async products(query: ProductQueryDto) {
-    const where: Prisma.ProductWhereInput = {
+    const baseWhere: Prisma.ProductWhereInput = {
       isActive: true,
       variant: { isNot: null },
-      ...(query.categoryId ? { categories: { some: { categoryId: query.categoryId } } } : {}),
       ...(query.search
         ? {
             OR: [
@@ -51,6 +50,11 @@ export class CatalogService {
     };
     const orderBy = this.orderBy(query.sort);
     const [items, total] = await this.prisma.$transaction(async (tx) => {
+      const categoryIds = query.categoryId ? await this.categoryScope(tx, query.categoryId) : undefined;
+      const where: Prisma.ProductWhereInput = {
+        ...baseWhere,
+        ...(categoryIds ? { categories: { some: { categoryId: { in: categoryIds } } } } : {}),
+      };
       const page = await tx.product.findMany({
         where,
         include: productInclude,
@@ -67,6 +71,24 @@ export class CatalogService {
       limit: query.limit,
       total,
     };
+  }
+
+  private async categoryScope(tx: Prisma.TransactionClient, categoryId: string): Promise<string[]> {
+    const categories = await tx.category.findMany({ select: { id: true, parentId: true } });
+    const categoryIds = new Set([categoryId]);
+
+    let foundDescendant = true;
+    while (foundDescendant) {
+      foundDescendant = false;
+      for (const category of categories) {
+        if (category.parentId && categoryIds.has(category.parentId) && !categoryIds.has(category.id)) {
+          categoryIds.add(category.id);
+          foundDescendant = true;
+        }
+      }
+    }
+
+    return [...categoryIds];
   }
 
   async product(productId: string) {

--- a/frontend/src/components/Breadcrumbs/Breadcrumbs.scss
+++ b/frontend/src/components/Breadcrumbs/Breadcrumbs.scss
@@ -1,20 +1,39 @@
 .breadcrumbs {
-  font-family: "Roboto", sans-serif;
-  font-size: 16px;
-  margin-bottom: 10px;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+
+  ol,
+  li {
+    display: flex;
+    margin: 0;
+    padding: 0;
+    align-items: center;
+    list-style: none;
+  }
+
+  ol {
+    flex-wrap: wrap;
+    gap: var(--space-1);
+  }
 
   a {
-    color: #000;
+    border-radius: 0.2rem;
+    color: inherit;
     text-decoration: none;
-    cursor: pointer;
 
     &:hover {
-      text-decoration: underline;
+      color: var(--color-ink);
     }
   }
 
-  .breadcrumb-separatour {
-    margin: 0 0.5rem;
-    color: #000;
+  [aria-current="page"] {
+    color: var(--color-ink);
   }
+}
+
+.breadcrumbs__separator {
+  width: 1.4rem;
+  height: 1.4rem;
+  margin-left: var(--space-1);
+  flex: none;
 }

--- a/frontend/src/components/Breadcrumbs/Breadcrumbs.spec.tsx
+++ b/frontend/src/components/Breadcrumbs/Breadcrumbs.spec.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+
+import Breadcrumbs from "./Breadcrumbs";
+
+describe("Breadcrumbs", () => {
+  it("marks the last category as the current page", () => {
+    render(
+      <MemoryRouter>
+        <Breadcrumbs
+          crumbs={[
+            { name: "Fitness", path: "/catalog/fitness" },
+            { name: "Yoga", path: "/catalog/fitness/yoga" },
+          ]}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole("navigation", { name: "Breadcrumb" })).toBeVisible();
+    expect(screen.getByText("Yoga")).toHaveAttribute("aria-current", "page");
+    expect(screen.getByRole("link", { name: "Fitness" })).toHaveAttribute("href", "/catalog/fitness");
+  });
+});

--- a/frontend/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/frontend/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -1,5 +1,6 @@
-import React from "react";
+import { PiCaretRight } from "react-icons/pi";
 import { Link } from "react-router-dom";
+
 import "./Breadcrumbs.scss";
 
 export interface Crumb {
@@ -11,21 +12,37 @@ interface BreadcrumbsProps {
   crumbs: Crumb[];
 }
 
-const Breadcrumbs: React.FC<BreadcrumbsProps> = ({ crumbs }) => {
-  return (
-    <div className="breadcrumbs">
-      <Link to="/">Home</Link>
-      {/* use '>' as a divider */}
-      <span className="breadcrumb-separatour">&gt;</span>
-      <Link to="/catalog">Catalog</Link>
+const BreadcrumbSeparator = () => <PiCaretRight aria-hidden="true" className="breadcrumbs__separator" />;
 
-      {crumbs.map((crumb, idx) => (
-        <React.Fragment key={idx}>
-          <span className="breadcrumb-separatour">&gt;</span>
-          <Link to={crumb.path}>{crumb.name}</Link>
-        </React.Fragment>
-      ))}
-    </div>
+const Breadcrumbs = ({ crumbs }: BreadcrumbsProps) => {
+  return (
+    <nav aria-label="Breadcrumb" className="breadcrumbs">
+      <ol>
+        <li>
+          <Link to="/">Home</Link>
+          <BreadcrumbSeparator />
+        </li>
+        <li>
+          {crumbs.length ? <Link to="/catalog">Catalog</Link> : <span aria-current="page">Catalog</span>}
+          {crumbs.length > 0 && <BreadcrumbSeparator />}
+        </li>
+        {crumbs.map((crumb, index) => {
+          const isCurrentPage = index === crumbs.length - 1;
+          return (
+            <li key={crumb.path}>
+              {isCurrentPage ? (
+                <span aria-current="page">{crumb.name}</span>
+              ) : (
+                <>
+                  <Link to={crumb.path}>{crumb.name}</Link>
+                  <BreadcrumbSeparator />
+                </>
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
   );
 };
 

--- a/frontend/src/components/Catalog/CategoryFilter/CategoryFilter.scss
+++ b/frontend/src/components/Catalog/CategoryFilter/CategoryFilter.scss
@@ -1,0 +1,61 @@
+.category-filter {
+  width: 100%;
+  padding: var(--space-5) var(--space-6);
+  border: var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+}
+
+.category-filter__header {
+  display: flex;
+  padding-bottom: var(--space-5);
+  border-bottom: var(--border-subtle);
+  align-items: center;
+  justify-content: space-between;
+
+  h2 {
+    margin: 0;
+    font-size: var(--font-size-lg);
+  }
+
+  svg {
+    width: 2rem;
+    height: 2rem;
+    color: var(--color-text-muted);
+  }
+}
+
+.category-filter__list {
+  display: flex;
+  margin: 0;
+  padding: var(--space-4) 0 0;
+  flex-direction: column;
+  gap: var(--space-1);
+  list-style: none;
+}
+
+.category-filter__link {
+  display: flex;
+  min-height: 4rem;
+  padding: var(--space-2);
+  border-radius: var(--radius-sm);
+  align-items: center;
+  justify-content: space-between;
+  color: var(--color-text-muted);
+  text-decoration: none;
+  transition:
+    background-color var(--transition-fast),
+    color var(--transition-fast);
+
+  &:hover,
+  &[aria-current="page"] {
+    background: var(--color-surface-subtle);
+    color: var(--color-ink);
+  }
+
+  svg {
+    width: 1.6rem;
+    height: 1.6rem;
+    flex: none;
+  }
+}

--- a/frontend/src/components/Catalog/CategoryFilter/CategoryFilter.spec.tsx
+++ b/frontend/src/components/Catalog/CategoryFilter/CategoryFilter.spec.tsx
@@ -1,0 +1,26 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+
+import { CategoryFilter } from "./CategoryFilter";
+
+describe("CategoryFilter", () => {
+  it("renders supported category links and closes after navigation", () => {
+    const onNavigate = vi.fn();
+
+    render(
+      <MemoryRouter>
+        <CategoryFilter
+          items={[{ id: "balls", isActive: true, name: "Balls", to: "/catalog/balls" }]}
+          onNavigate={onNavigate}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole("link", { name: "Balls" })).toHaveAttribute("aria-current", "page");
+    expect(screen.getByRole("link", { name: "All products" })).toHaveAttribute("href", "/catalog");
+
+    fireEvent.click(screen.getByRole("link", { name: "Balls" }));
+    expect(onNavigate).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/components/Catalog/CategoryFilter/CategoryFilter.tsx
+++ b/frontend/src/components/Catalog/CategoryFilter/CategoryFilter.tsx
@@ -1,3 +1,4 @@
+import { useId } from "react";
 import { PiCaretRight, PiSlidersHorizontal } from "react-icons/pi";
 import { Link } from "react-router-dom";
 
@@ -17,10 +18,12 @@ type CategoryFilterProps = {
 };
 
 export function CategoryFilter({ className = "", items, onNavigate }: CategoryFilterProps) {
+  const titleId = useId();
+
   return (
-    <section aria-labelledby="category-filter-title" className={`category-filter ${className}`.trim()}>
+    <section aria-labelledby={titleId} className={`category-filter ${className}`.trim()}>
       <div className="category-filter__header">
-        <h2 id="category-filter-title">Categories</h2>
+        <h2 id={titleId}>Categories</h2>
         <PiSlidersHorizontal aria-hidden="true" />
       </div>
 

--- a/frontend/src/components/Catalog/CategoryFilter/CategoryFilter.tsx
+++ b/frontend/src/components/Catalog/CategoryFilter/CategoryFilter.tsx
@@ -1,0 +1,50 @@
+import { PiCaretRight, PiSlidersHorizontal } from "react-icons/pi";
+import { Link } from "react-router-dom";
+
+import "./CategoryFilter.scss";
+
+export type CategoryFilterItem = {
+  id: string;
+  name: string;
+  to: string;
+  isActive?: boolean;
+};
+
+type CategoryFilterProps = {
+  items: CategoryFilterItem[];
+  onNavigate?: () => void;
+  className?: string;
+};
+
+export function CategoryFilter({ className = "", items, onNavigate }: CategoryFilterProps) {
+  return (
+    <section aria-labelledby="category-filter-title" className={`category-filter ${className}`.trim()}>
+      <div className="category-filter__header">
+        <h2 id="category-filter-title">Categories</h2>
+        <PiSlidersHorizontal aria-hidden="true" />
+      </div>
+
+      <ul className="category-filter__list">
+        <li>
+          <Link className="category-filter__link" onClick={onNavigate} to="/catalog">
+            <span>All products</span>
+            <PiCaretRight aria-hidden="true" />
+          </Link>
+        </li>
+        {items.map(({ id, isActive, name, to }) => (
+          <li key={id}>
+            <Link
+              aria-current={isActive ? "page" : undefined}
+              className="category-filter__link"
+              onClick={onNavigate}
+              to={to}
+            >
+              <span>{name}</span>
+              <PiCaretRight aria-hidden="true" />
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/frontend/src/components/Catalog/FilterDrawer/FilterDrawer.scss
+++ b/frontend/src/components/Catalog/FilterDrawer/FilterDrawer.scss
@@ -1,0 +1,55 @@
+.filter-drawer__backdrop {
+  position: fixed;
+  z-index: 1000;
+  display: flex;
+  inset: 0;
+  background: rgb(0 0 0 / 45%);
+  justify-content: flex-end;
+}
+
+.filter-drawer {
+  width: min(100%, 38rem);
+  height: 100%;
+  padding: var(--space-5);
+  overflow-y: auto;
+  background: var(--color-surface);
+  box-shadow: -1rem 0 3rem rgb(0 0 0 / 15%);
+}
+
+.filter-drawer__header {
+  display: flex;
+  padding-bottom: var(--space-5);
+  border-bottom: var(--border-subtle);
+  align-items: center;
+  justify-content: space-between;
+
+  h2 {
+    margin: 0;
+    font-size: var(--font-size-xl);
+  }
+
+  button {
+    display: inline-flex;
+    width: 4rem;
+    height: 4rem;
+    padding: 0;
+    border: 0;
+    border-radius: var(--radius-pill);
+    background: var(--color-surface-subtle);
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+  }
+
+  svg {
+    width: 2.2rem;
+    height: 2.2rem;
+  }
+}
+
+.filter-drawer__content {
+  display: flex;
+  padding-top: var(--space-5);
+  flex-direction: column;
+  gap: var(--space-5);
+}

--- a/frontend/src/components/Catalog/FilterDrawer/FilterDrawer.spec.tsx
+++ b/frontend/src/components/Catalog/FilterDrawer/FilterDrawer.spec.tsx
@@ -1,0 +1,32 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { FilterDrawer } from "./FilterDrawer";
+
+describe("FilterDrawer", () => {
+  it("renders as a modal dialog and closes with Escape", () => {
+    const onClose = vi.fn();
+
+    render(
+      <FilterDrawer isOpen onClose={onClose}>
+        <p>Available filters</p>
+      </FilterDrawer>
+    );
+
+    expect(screen.getByRole("dialog", { name: "Catalog options" })).toBeVisible();
+    expect(document.body.style.overflow).toBe("hidden");
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("does not render while closed", () => {
+    render(
+      <FilterDrawer isOpen={false} onClose={vi.fn()}>
+        <p>Available filters</p>
+      </FilterDrawer>
+    );
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/Catalog/FilterDrawer/FilterDrawer.tsx
+++ b/frontend/src/components/Catalog/FilterDrawer/FilterDrawer.tsx
@@ -1,0 +1,50 @@
+import { useEffect, type ReactNode } from "react";
+import { PiX } from "react-icons/pi";
+
+import "./FilterDrawer.scss";
+
+type FilterDrawerProps = {
+  children: ReactNode;
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+export function FilterDrawer({ children, isOpen, onClose }: FilterDrawerProps) {
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const previousOverflow = document.body.style.overflow;
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+
+    document.body.style.overflow = "hidden";
+    document.addEventListener("keydown", closeOnEscape);
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      document.removeEventListener("keydown", closeOnEscape);
+    };
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="filter-drawer__backdrop"
+      onMouseDown={(event) => {
+        if (event.currentTarget === event.target) onClose();
+      }}
+    >
+      <aside aria-labelledby="filter-drawer-title" aria-modal="true" className="filter-drawer" role="dialog">
+        <div className="filter-drawer__header">
+          <h2 id="filter-drawer-title">Catalog options</h2>
+          <button aria-label="Close catalog options" onClick={onClose} type="button">
+            <PiX aria-hidden="true" />
+          </button>
+        </div>
+        <div className="filter-drawer__content">{children}</div>
+      </aside>
+    </div>
+  );
+}

--- a/frontend/src/components/Sorting/Sorting.scss
+++ b/frontend/src/components/Sorting/Sorting.scss
@@ -1,53 +1,54 @@
+@use "../../assets/styles/tokens" as tokens;
+
 .sorting {
-  position: relative;
-  display: inline-block;
-  font-family: "Roboto", sans-serif;
-}
-
-.toggle {
-  background: none;
-  border: 1px solid #f0eeed;
-  border-radius: 4px;
-  padding: 8px 12px;
-  font-size: 16px;
-  cursor: pointer;
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  font-family: "Roboto", sans-serif;
+  gap: var(--space-1);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  white-space: nowrap;
 }
 
-.caret {
-  margin-left: 8px;
-  font-size: 14px;
-  font-family: "Roboto", sans-serif;
+.sorting__label {
+  flex: none;
 }
 
-.sorting-dropdown {
-  position: absolute;
-  top: calc(100% + 4px);
-  right: 0;
-  background: #fff;
-  border: 1px solid #f0eeed;
-  border-radius: 4px;
-  list-style: none;
-  padding: 4px 0;
-  margin: 0;
-  width: 100%;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
-  z-index: 10;
+.sorting__control {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
 }
 
-.option {
-  width: 100%;
-  padding: 8px 12px;
-  background: none;
-  border: none;
-  text-align: left;
-  font-size: 16px;
+.sorting__select {
+  min-height: 4rem;
+  padding: var(--space-2) var(--space-8) var(--space-2) var(--space-2);
+  appearance: none;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--color-ink);
   cursor: pointer;
-  font-family: "Roboto", sans-serif;
+  font-weight: var(--font-weight-medium);
 }
 
-.option:hover {
-  background-color: #f0eeed;
+.sorting__icon {
+  position: absolute;
+  right: var(--space-2);
+  width: 1.4rem;
+  height: 1.4rem;
+  color: var(--color-ink);
+  pointer-events: none;
+}
+
+@media (max-width: tokens.$breakpoint-mobile) {
+  .sorting {
+    width: 100%;
+    justify-content: space-between;
+    font-size: var(--font-size-md);
+  }
+
+  .sorting__select {
+    border: var(--border-subtle);
+    background: var(--color-surface);
+  }
 }

--- a/frontend/src/components/Sorting/Sorting.spec.tsx
+++ b/frontend/src/components/Sorting/Sorting.spec.tsx
@@ -1,0 +1,19 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import Sorting from "./Sorting";
+
+describe("Sorting", () => {
+  it("shows the current sort and reports a new selection", () => {
+    const onSortChange = vi.fn();
+
+    render(<Sorting currentSort="default" onSortChange={onSortChange} />);
+
+    const select = screen.getByRole("combobox", { name: "Sort products" });
+    expect(select).toHaveValue("default");
+
+    fireEvent.change(select, { target: { value: "price asc" } });
+
+    expect(onSortChange).toHaveBeenCalledWith("price asc");
+  });
+});

--- a/frontend/src/components/Sorting/Sorting.tsx
+++ b/frontend/src/components/Sorting/Sorting.tsx
@@ -1,4 +1,5 @@
-import React, { useState, useRef, useEffect } from "react";
+import { PiCaretDownBold } from "react-icons/pi";
+
 import "./Sorting.scss";
 
 export type SortOption = "default" | "price asc" | "price desc" | "name asc" | "name desc";
@@ -6,58 +7,39 @@ export type SortOption = "default" | "price asc" | "price desc" | "name asc" | "
 export interface SortingProps {
   currentSort: SortOption;
   onSortChange: (newSort: SortOption) => void;
+  className?: string;
 }
 
 const LABELS: Record<SortOption, string> = {
   default: "Most relevant",
-  "price asc": "Price low to hight",
-  "price desc": "Price hight to low",
-  "name asc": "Name A to Z",
-  "name desc": "Name Z to A",
+  "price asc": "Price: low to high",
+  "price desc": "Price: high to low",
+  "name asc": "Name: A to Z",
+  "name desc": "Name: Z to A",
 };
 
-export const Sorting: React.FC<SortingProps> = ({ currentSort, onSortChange }) => {
-  const [open, setOpen] = useState(false);
-  const dropdownRef = useRef<HTMLDivElement>(null);
+const SORT_OPTIONS = Object.entries(LABELS) as [SortOption, string][];
 
-  useEffect(() => {
-    function handleClickOutside(event: MouseEvent) {
-      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
-        setOpen(false);
-      }
-    }
-    if (open) {
-      document.addEventListener("mousedown", handleClickOutside);
-    } else {
-      document.removeEventListener("mousedown", handleClickOutside);
-    }
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, [open]);
-
-  const handleOptionClick = (option: SortOption) => {
-    setOpen(false);
-    if (option !== currentSort) {
-      onSortChange(option);
-    }
-  };
-
+export const Sorting = ({ currentSort, onSortChange, className = "" }: SortingProps) => {
   return (
-    <div className="sorting" ref={dropdownRef}>
-      <button type="button" className="toggle" onClick={() => setOpen((prev) => !prev)}>
-        Sort: {LABELS[currentSort]} <span className="caret">⋁</span>
-      </button>
-      {open && (
-        <ul className="sorting-dropdown">
-          {(Object.keys(LABELS) as SortOption[]).map((opt) => (
-            <li key={opt}>
-              <button type="button" className="option" onClick={() => handleOptionClick(opt)}>
-                {LABELS[opt]}
-              </button>
-            </li>
+    <label className={`sorting ${className}`.trim()}>
+      <span className="sorting__label">Sort by:</span>
+      <span className="sorting__control">
+        <select
+          aria-label="Sort products"
+          className="sorting__select"
+          onChange={(event) => onSortChange(event.target.value as SortOption)}
+          value={currentSort}
+        >
+          {SORT_OPTIONS.map(([value, label]) => (
+            <option key={value} value={value}>
+              {label}
+            </option>
           ))}
-        </ul>
-      )}
-    </div>
+        </select>
+        <PiCaretDownBold aria-hidden="true" className="sorting__icon" />
+      </span>
+    </label>
   );
 };
 

--- a/frontend/src/components/common/Pagination/Pagination.scss
+++ b/frontend/src/components/common/Pagination/Pagination.scss
@@ -1,0 +1,98 @@
+@use "../../../assets/styles/tokens" as tokens;
+
+.pagination {
+  display: flex;
+  padding-top: var(--space-5);
+  border-top: var(--border-subtle);
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+}
+
+.pagination__direction,
+.pagination__page {
+  display: inline-flex;
+  min-width: 4rem;
+  min-height: 4rem;
+  border: var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  transition:
+    border-color var(--transition-fast),
+    background-color var(--transition-fast);
+
+  &:hover:not(:disabled) {
+    border-color: var(--color-ink);
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.4;
+  }
+}
+
+.pagination__direction {
+  padding-inline: var(--space-4);
+  gap: var(--space-2);
+
+  svg {
+    width: 1.8rem;
+    height: 1.8rem;
+  }
+}
+
+.pagination__pages {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-1);
+}
+
+.pagination__page {
+  border-color: transparent;
+  color: var(--color-text-muted);
+
+  &[aria-current="page"] {
+    background: var(--color-surface-subtle);
+    color: var(--color-ink);
+  }
+}
+
+.pagination__ellipsis {
+  display: inline-flex;
+  width: 3.2rem;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text-muted);
+}
+
+@media (max-width: tokens.$breakpoint-mobile) {
+  .pagination {
+    gap: var(--space-2);
+  }
+
+  .pagination__direction {
+    padding-inline: var(--space-3);
+
+    span {
+      display: none;
+    }
+  }
+
+  .pagination__pages {
+    gap: 0;
+  }
+
+  .pagination__page {
+    min-width: 3.6rem;
+  }
+
+  .pagination__ellipsis {
+    width: 2.4rem;
+  }
+}

--- a/frontend/src/components/common/Pagination/Pagination.spec.tsx
+++ b/frontend/src/components/common/Pagination/Pagination.spec.tsx
@@ -1,0 +1,26 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { Pagination } from "./Pagination";
+
+describe("Pagination", () => {
+  it("moves between pages and marks the current page", () => {
+    const onPageChange = vi.fn();
+
+    render(<Pagination currentPage={2} onPageChange={onPageChange} pageSize={6} totalItems={18} />);
+
+    expect(screen.getByRole("button", { name: "Go to page 2" })).toHaveAttribute("aria-current", "page");
+
+    fireEvent.click(screen.getByRole("button", { name: "Previous page" }));
+    fireEvent.click(screen.getByRole("button", { name: "Next page" }));
+    fireEvent.click(screen.getByRole("button", { name: "Go to page 3" }));
+
+    expect(onPageChange.mock.calls).toEqual([[1], [3], [3]]);
+  });
+
+  it("hides when all products fit on one page", () => {
+    const { container } = render(<Pagination currentPage={1} onPageChange={vi.fn()} pageSize={6} totalItems={6} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/frontend/src/components/common/Pagination/Pagination.tsx
+++ b/frontend/src/components/common/Pagination/Pagination.tsx
@@ -1,0 +1,78 @@
+import { PiArrowLeft, PiArrowRight } from "react-icons/pi";
+
+import "./Pagination.scss";
+
+type PaginationItem = number | `ellipsis-${string}`;
+
+type PaginationProps = {
+  currentPage: number;
+  totalItems: number;
+  pageSize: number;
+  onPageChange: (page: number) => void;
+  className?: string;
+};
+
+function paginationItems(currentPage: number, totalPages: number): PaginationItem[] {
+  if (totalPages <= 7) return Array.from({ length: totalPages }, (_, index) => index + 1);
+
+  const visiblePages = [...new Set([1, currentPage - 1, currentPage, currentPage + 1, totalPages])]
+    .filter((page) => page >= 1 && page <= totalPages)
+    .sort((left, right) => left - right);
+
+  return visiblePages.flatMap((page, index) => {
+    const previousPage = visiblePages[index - 1];
+    return previousPage && page - previousPage > 1 ? [`ellipsis-${previousPage}-${page}` as const, page] : [page];
+  });
+}
+
+export function Pagination({ className = "", currentPage, onPageChange, pageSize, totalItems }: PaginationProps) {
+  const totalPages = Math.ceil(totalItems / pageSize);
+  if (totalPages <= 1) return null;
+
+  return (
+    <nav aria-label="Catalog pagination" className={`pagination ${className}`.trim()}>
+      <button
+        aria-label="Previous page"
+        className="pagination__direction"
+        disabled={currentPage === 1}
+        onClick={() => onPageChange(currentPage - 1)}
+        type="button"
+      >
+        <PiArrowLeft aria-hidden="true" />
+        <span>Previous</span>
+      </button>
+
+      <div className="pagination__pages">
+        {paginationItems(currentPage, totalPages).map((item) =>
+          typeof item === "number" ? (
+            <button
+              aria-current={item === currentPage ? "page" : undefined}
+              aria-label={`Go to page ${item}`}
+              className="pagination__page"
+              key={item}
+              onClick={() => onPageChange(item)}
+              type="button"
+            >
+              {item}
+            </button>
+          ) : (
+            <span aria-hidden="true" className="pagination__ellipsis" key={item}>
+              …
+            </span>
+          )
+        )}
+      </div>
+
+      <button
+        aria-label="Next page"
+        className="pagination__direction"
+        disabled={currentPage === totalPages}
+        onClick={() => onPageChange(currentPage + 1)}
+        type="button"
+      >
+        <span>Next</span>
+        <PiArrowRight aria-hidden="true" />
+      </button>
+    </nav>
+  );
+}

--- a/frontend/src/pages/Category/Category.scss
+++ b/frontend/src/pages/Category/Category.scss
@@ -1,5 +1,3 @@
-@use "../../assets/styles/tokens" as tokens;
-
 .category-page {
   padding-block: var(--space-6) var(--space-20);
 
@@ -159,13 +157,13 @@
   }
 }
 
-@media (max-width: tokens.$breakpoint-desktop) {
+@media (max-width: 1100px) {
   .category-products {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
-@media (max-width: tokens.$breakpoint-tablet) {
+@media (max-width: 768px) {
   .category-page {
     padding-block: var(--space-5) var(--space-16);
 
@@ -221,7 +219,7 @@
   }
 }
 
-@media (max-width: tokens.$breakpoint-mobile) {
+@media (max-width: 480px) {
   .category-page__heading {
     display: block;
 

--- a/frontend/src/pages/Category/Category.scss
+++ b/frontend/src/pages/Category/Category.scss
@@ -1,130 +1,253 @@
+@use "../../assets/styles/tokens" as tokens;
+
 .category-page {
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  padding: 0 20px;
-  box-sizing: border-box;
-  font-family: "Roboto", sans-serif;
-}
+  padding-block: var(--space-6) var(--space-20);
 
-.loading {
-  height: 100vh;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}
-
-.category-content {
-  display: flex;
-  gap: 20px;
-  align-items: flex-start;
-}
-
-.category-subcats-filter {
-  width: 250px;
-  border: 1px solid #f0eeed;
-  border-radius: 10px;
-  padding: 10px;
-  box-sizing: border-box;
-
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
-}
-
-.category-list {
-  display: flex;
-  flex-wrap: wrap;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-.category-content-colomn {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-}
-
-.category-title-sort {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 1rem;
-}
-
-.mobile-filter-toggle {
-  display: none;
-  background: none;
-  border: none;
-  padding: 0.25rem;
-  cursor: pointer;
-  color: #333;
-
-  svg {
-    width: 24px;
-    height: 24px;
+  > .breadcrumbs {
+    margin-bottom: var(--space-6);
   }
 }
 
-.mobile-filter-overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100vw;
-  height: 100vh;
-  background-color: #fff;
-  z-index: 1000;
+.category-page__layout {
+  display: grid;
+  grid-template-columns: 25rem minmax(0, 1fr);
+  align-items: start;
+  gap: var(--space-5);
+}
+
+.category-page__sidebar {
+  position: sticky;
+  top: var(--space-5);
+}
+
+.category-page__main {
+  min-width: 0;
+}
+
+.category-page__toolbar {
   display: flex;
-  flex-direction: column;
+  min-height: 4.8rem;
+  margin-bottom: var(--space-5);
   align-items: center;
-  padding: 1.5rem;
-  box-sizing: border-box;
-  overflow-y: auto;
+  justify-content: space-between;
+  gap: var(--space-4);
 }
 
-.close-overlay {
-  position: absolute;
-  top: 1rem;
-  right: 1rem;
-  background: none;
-  border: none;
-  cursor: pointer;
-  color: #333;
-}
-
-.category-subcats-filter-inner {
-  margin: auto auto;
+.category-page__heading {
   display: flex;
-  flex-direction: column;
-  gap: 1rem;
+  min-width: 0;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+
+  h1 {
+    margin: 0;
+    font-size: var(--font-size-2xl);
+    line-height: var(--line-height-heading);
+  }
+
+  p {
+    color: var(--color-text-muted);
+    font-size: var(--font-size-sm);
+  }
 }
 
-.load-more-wrapper {
-  display: flex;
+.category-page__filter-toggle {
+  display: none;
+  width: 4rem;
+  height: 4rem;
+  padding: 0;
+  border: 0;
+  border-radius: var(--radius-pill);
+  background: var(--color-surface-subtle);
+  align-items: center;
   justify-content: center;
-  text-align: center;
-  margin-top: 2rem;
-}
-
-.load-more-btn {
-  background: #fff;
-  color: #000;
   cursor: pointer;
+
+  svg {
+    width: 2rem;
+    height: 2rem;
+  }
 }
 
-.no-more-products {
-  font-size: 2rem;
-  text-align: center;
-  color: #888;
-  margin: 2rem 0;
-}
+.category-products {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  align-items: stretch;
+  justify-content: stretch;
+  gap: var(--space-8) var(--space-5);
 
-@media (max-width: 600px) {
-  .category-subcats-filter {
+  .product-list__item,
+  .product-card {
+    width: 100%;
+  }
+
+  .product-card {
+    border: 0;
+    border-radius: 0;
+
+    &:hover {
+      box-shadow: none;
+    }
+  }
+
+  .product-card__img-wrapper {
+    border-radius: var(--radius-md);
+  }
+
+  .product-card__info {
+    padding: var(--space-4) 0 0;
+    flex: 0;
+  }
+
+  .product-card__description {
     display: none;
   }
 
-  .category-title-sort .mobile-filter-toggle {
+  .product-card__prices {
+    margin-top: 0;
+  }
+
+  .product-card__add-to-cart {
+    width: 100%;
+    min-height: 4.2rem;
+    margin: var(--space-4) 0 0;
+    padding: var(--space-2) var(--space-4);
+  }
+}
+
+.category-page__pagination {
+  margin-top: var(--space-8);
+}
+
+.category-page__status {
+  display: flex;
+  min-height: 32rem;
+  padding: var(--space-8);
+  border: var(--border-subtle);
+  border-radius: var(--radius-md);
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: var(--space-4);
+  color: var(--color-text-muted);
+  text-align: center;
+}
+
+.category-page__spinner {
+  width: 3.2rem;
+  height: 3.2rem;
+  border: 0.3rem solid var(--color-border);
+  border-top-color: var(--color-ink);
+  border-radius: var(--radius-pill);
+  animation: catalog-spin 800ms linear infinite;
+}
+
+.category-page__retry {
+  min-height: 4rem;
+  padding-inline: var(--space-6);
+  border: 0;
+  border-radius: var(--radius-pill);
+  background: var(--color-ink);
+  color: var(--color-surface);
+  cursor: pointer;
+}
+
+@keyframes catalog-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (max-width: tokens.$breakpoint-desktop) {
+  .category-products {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: tokens.$breakpoint-tablet) {
+  .category-page {
+    padding-block: var(--space-5) var(--space-16);
+
+    > .breadcrumbs {
+      margin-bottom: var(--space-4);
+    }
+  }
+
+  .category-page__layout {
+    display: block;
+  }
+
+  .category-page__sidebar,
+  .category-page__desktop-sort {
+    display: none;
+  }
+
+  .category-page__filter-toggle {
     display: inline-flex;
+    flex: none;
+  }
+
+  .category-page__toolbar {
+    margin-bottom: var(--space-5);
+  }
+
+  .category-page__heading {
+    gap: var(--space-2);
+
+    h1 {
+      font-size: var(--font-size-xl);
+    }
+  }
+
+  .category-products {
+    gap: var(--space-8) var(--space-3);
+
+    .product-card__name {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .product-card__add-to-cart {
+      padding-inline: var(--space-2);
+      font-size: var(--font-size-sm);
+    }
+  }
+
+  .filter-drawer .category-filter {
+    padding: 0;
+    border: 0;
+  }
+}
+
+@media (max-width: tokens.$breakpoint-mobile) {
+  .category-page__heading {
+    display: block;
+
+    p {
+      margin-top: var(--space-1);
+    }
+  }
+
+  .category-products {
+    .product-card__info {
+      padding-top: var(--space-3);
+      gap: var(--space-2);
+    }
+
+    .product-card__prices {
+      gap: var(--space-2);
+    }
+
+    .product-card__discount {
+      padding: var(--space-1) var(--space-2);
+    }
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .category-page__spinner {
+    animation: none;
   }
 }

--- a/frontend/src/pages/Category/Category.spec.tsx
+++ b/frontend/src/pages/Category/Category.spec.tsx
@@ -1,0 +1,90 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { createMemoryRouter, RouterProvider } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { fetchChildCategories } from "../../services/categoryService/categoryService";
+import { fetchProductPage } from "../../services/productService/productService";
+import type { Product } from "../../services/productService/types";
+import CategoryPage from "./Category";
+
+vi.mock("../../services/categoryService/categoryService", () => ({
+  fetchCategoryBySlug: vi.fn(),
+  fetchChildCategories: vi.fn(),
+}));
+
+vi.mock("../../services/productService/productService", () => ({
+  fetchProductPage: vi.fn(),
+}));
+
+vi.mock("../../components/productList/ProductList", () => ({
+  default: ({ products }: { products: Product[] }) => (
+    <ul aria-label="Products">
+      {products.map((product) => (
+        <li key={product.id}>{product.name}</li>
+      ))}
+    </ul>
+  ),
+}));
+
+function product(index: number): Product {
+  return {
+    id: `product-${index}`,
+    slug: `product-${index}`,
+    name: `Product ${index}`,
+    description: "Catalog product",
+    imgUrls: [`product-${index}.jpg`],
+    currentPrice: 1000 + index,
+    oldPrice: 1200 + index,
+  };
+}
+
+function renderCatalog(initialEntry = "/catalog") {
+  const router = createMemoryRouter([{ path: "/catalog/*", element: <CategoryPage /> }], {
+    initialEntries: [initialEntry],
+  });
+  render(<RouterProvider router={router} />);
+  return router;
+}
+
+describe("CategoryPage", () => {
+  beforeEach(() => {
+    vi.mocked(fetchChildCategories).mockReset();
+    vi.mocked(fetchProductPage).mockReset();
+    vi.mocked(fetchChildCategories).mockResolvedValue([{ id: "balls", name: "Balls", slug: "balls", parentId: null }]);
+    vi.mocked(fetchProductPage).mockImplementation(async ({ offset = 0, limit = 6 }) => ({
+      items: Array.from({ length: offset ? 2 : 6 }, (_, index) => product(offset + index + 1)),
+      offset,
+      limit,
+      total: 8,
+    }));
+  });
+
+  it("loads server pages and reports the visible product range", async () => {
+    renderCatalog();
+
+    expect(await screen.findByText("Showing 1-6 of 8 products")).toBeVisible();
+    expect(fetchProductPage).toHaveBeenCalledWith(expect.objectContaining({ limit: 6, offset: 0 }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Next page" }));
+
+    expect(await screen.findByText("Showing 7-8 of 8 products")).toBeVisible();
+    expect(fetchProductPage).toHaveBeenLastCalledWith(expect.objectContaining({ limit: 6, offset: 6 }));
+  });
+
+  it("stores sorting in the URL and exposes categories in the mobile drawer", async () => {
+    const router = renderCatalog();
+
+    await screen.findByText("Showing 1-6 of 8 products");
+    fireEvent.change(screen.getByRole("combobox", { name: "Sort products" }), {
+      target: { value: "price desc" },
+    });
+
+    await waitFor(() => expect(router.state.location.search).toContain("sort=price+desc"));
+    expect(fetchProductPage).toHaveBeenLastCalledWith(expect.objectContaining({ sort: "price desc" }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Open catalog options" }));
+
+    expect(screen.getByRole("dialog", { name: "Catalog options" })).toBeVisible();
+    expect(screen.getAllByRole("link", { name: "Balls" })).toHaveLength(2);
+  });
+});

--- a/frontend/src/pages/Category/Category.spec.tsx
+++ b/frontend/src/pages/Category/Category.spec.tsx
@@ -51,12 +51,15 @@ describe("CategoryPage", () => {
     vi.mocked(fetchChildCategories).mockReset();
     vi.mocked(fetchProductPage).mockReset();
     vi.mocked(fetchChildCategories).mockResolvedValue([{ id: "balls", name: "Balls", slug: "balls", parentId: null }]);
-    vi.mocked(fetchProductPage).mockImplementation(async ({ offset = 0, limit = 6 }) => ({
-      items: Array.from({ length: offset ? 2 : 6 }, (_, index) => product(offset + index + 1)),
-      offset,
-      limit,
-      total: 8,
-    }));
+    vi.mocked(fetchProductPage).mockImplementation(async (query = {}) => {
+      const { offset = 0, limit = 6 } = query;
+      return {
+        items: Array.from({ length: offset ? 2 : 6 }, (_, index) => product(offset + index + 1)),
+        offset,
+        limit,
+        total: 8,
+      };
+    });
   });
 
   it("loads server pages and reports the visible product range", async () => {

--- a/frontend/src/pages/Category/Category.spec.tsx
+++ b/frontend/src/pages/Category/Category.spec.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { createMemoryRouter, RouterProvider } from "react-router-dom";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { fetchChildCategories } from "../../services/categoryService/categoryService";
@@ -38,12 +38,27 @@ function product(index: number): Product {
   };
 }
 
+function LocationProbe() {
+  const location = useLocation();
+  return <output aria-label="Location search">{location.search}</output>;
+}
+
 function renderCatalog(initialEntry = "/catalog") {
-  const router = createMemoryRouter([{ path: "/catalog/*", element: <CategoryPage /> }], {
-    initialEntries: [initialEntry],
-  });
-  render(<RouterProvider router={router} />);
-  return router;
+  render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <Routes>
+        <Route
+          element={
+            <>
+              <CategoryPage />
+              <LocationProbe />
+            </>
+          }
+          path="/catalog/*"
+        />
+      </Routes>
+    </MemoryRouter>
+  );
 }
 
 describe("CategoryPage", () => {
@@ -75,14 +90,16 @@ describe("CategoryPage", () => {
   });
 
   it("stores sorting in the URL and exposes categories in the mobile drawer", async () => {
-    const router = renderCatalog();
+    renderCatalog();
 
     await screen.findByText("Showing 1-6 of 8 products");
     fireEvent.change(screen.getByRole("combobox", { name: "Sort products" }), {
       target: { value: "price desc" },
     });
 
-    await waitFor(() => expect(router.state.location.search).toContain("sort=price+desc"));
+    await waitFor(() =>
+      expect(screen.getByRole("status", { name: "Location search" })).toHaveTextContent("sort=price+desc")
+    );
     expect(fetchProductPage).toHaveBeenLastCalledWith(expect.objectContaining({ sort: "price desc" }));
 
     fireEvent.click(screen.getByRole("button", { name: "Open catalog options" }));

--- a/frontend/src/pages/Category/Category.tsx
+++ b/frontend/src/pages/Category/Category.tsx
@@ -1,261 +1,240 @@
-import { useEffect, useState } from "react";
-import { useLocation, useNavigate } from "react-router-dom";
-import axios from "axios";
+import { useEffect, useMemo, useState } from "react";
+import { PiSlidersHorizontal } from "react-icons/pi";
+import { useLocation, useSearchParams } from "react-router-dom";
 
-import Breadcrumbs from "../../components/Breadcrumbs/Breadcrumbs";
-import { H3 } from "../../components/common/headings/H3";
-import Paragraph from "../../components/common/paragraph/paragraph";
-import Link from "../../components/common/link/link";
-import NotFoundPage from "../NotFound/NotFound";
+import Breadcrumbs, { type Crumb } from "../../components/Breadcrumbs/Breadcrumbs";
+import { CategoryFilter, type CategoryFilterItem } from "../../components/Catalog/CategoryFilter/CategoryFilter";
+import { FilterDrawer } from "../../components/Catalog/FilterDrawer/FilterDrawer";
+import { PageContainer } from "../../components/common/PageContainer/PageContainer";
+import { Pagination } from "../../components/common/Pagination/Pagination";
 import ProductList from "../../components/productList/ProductList";
-import Sorting from "../../components/Sorting/Sorting";
-
-import type { Product } from "../../services/productService/types";
-import type { Category } from "../../services/categoryService/types";
-import type { Crumb } from "../../components/Breadcrumbs/Breadcrumbs";
-import type { SortOption } from "../../components/Sorting/Sorting";
-
-import { fetchProducts } from "../../services/productService/productService";
+import Sorting, { type SortOption } from "../../components/Sorting/Sorting";
 import { fetchCategoryBySlug, fetchChildCategories } from "../../services/categoryService/categoryService";
+import type { Category } from "../../services/categoryService/types";
+import { fetchProductPage } from "../../services/productService/productService";
+import type { ProductPage } from "../../services/productService/types";
+import NotFoundPage from "../NotFound/NotFound";
 
 import "./Category.scss";
-import { IoMdOptions, IoMdClose } from "react-icons/io";
 
-const PAGE_SIZE = 20;
+const PAGE_SIZE = 6;
+const EMPTY_PAGE: ProductPage = { items: [], offset: 0, limit: PAGE_SIZE, total: 0 };
+const SORT_OPTIONS: SortOption[] = ["default", "price asc", "price desc", "name asc", "name desc"];
+
+class CategoryNotFoundError extends Error {}
+
+function readPage(value: string | null): number {
+  const page = Number(value);
+  return Number.isInteger(page) && page > 0 ? page : 1;
+}
+
+function readSort(value: string | null): SortOption {
+  return SORT_OPTIONS.includes(value as SortOption) ? (value as SortOption) : "default";
+}
+
+function apiSort(sort: SortOption): string | undefined {
+  switch (sort) {
+    case "price asc":
+    case "price desc":
+      return sort;
+    case "name asc":
+      return "name.en asc";
+    case "name desc":
+      return "name.en desc";
+    default:
+      return undefined;
+  }
+}
+
+function categoryPath(parentSegments: string[], slug: string): string {
+  return ["", "catalog", ...parentSegments, slug].join("/");
+}
+
+function pageSummary(page: ProductPage): string {
+  if (!page.total) return "0 products";
+  const firstItem = page.offset + 1;
+  const lastItem = Math.min(page.offset + page.items.length, page.total);
+  return `Showing ${firstItem}-${lastItem} of ${page.total} products`;
+}
 
 export default function CategoryPage() {
   const location = useLocation();
-  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
 
   const [breadcrumbs, setBreadcrumbs] = useState<Crumb[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  const [categoriesToShow, setCategoriesToShow] = useState<Category[]>([]);
-  const [products, setProducts] = useState<Product[]>([]);
-
+  const [categoryItems, setCategoryItems] = useState<CategoryFilterItem[]>([]);
   const [currentCategory, setCurrentCategory] = useState<Category | null>(null);
-  const [currentSort, setCurrentSort] = useState<SortOption>("default");
-
-  const [offset, setOffset] = useState(0);
-  const [isLoadingMore, setIsLoadingMore] = useState(false);
-  const [hasMore, setHasMore] = useState(true);
-
-  const [isMobileFilterOpen, setIsMobileFilterOpen] = useState(false);
+  const [productPage, setProductPage] = useState<ProductPage>(EMPTY_PAGE);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [categoryNotFound, setCategoryNotFound] = useState(false);
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  const [reloadKey, setReloadKey] = useState(0);
 
   const rawPath = location.pathname.replace(/^\/catalog\/?/, "");
-  const segments = rawPath === "" ? [] : rawPath.split("/");
-  const searchTerm = new URLSearchParams(location.search).get("search")?.trim() ?? "";
-
-  const getSortParam = (sortOption: SortOption): string | undefined => {
-    switch (sortOption) {
-      case "price asc":
-      case "price desc":
-        return sortOption;
-      case "name asc":
-        return "name.en asc";
-      case "name desc":
-        return "name.en desc";
-      default:
-        return undefined;
-    }
-  };
+  const segments = useMemo(() => (rawPath ? rawPath.split("/").filter(Boolean) : []), [rawPath]);
+  const currentPage = readPage(searchParams.get("page"));
+  const currentSort = readSort(searchParams.get("sort"));
+  const searchTerm = searchParams.get("search")?.trim() ?? "";
 
   useEffect(() => {
     let cancelled = false;
 
-    const loadInitial = async () => {
-      setLoading(true);
+    const loadCatalog = async () => {
+      setIsLoading(true);
       setError(null);
+      setCategoryNotFound(false);
 
       try {
         let parentId: string | null = null;
-        let lastCat: Category | null = null;
-        const crumbsTemp: Crumb[] = [];
+        let selectedCategory: Category | null = null;
+        const nextBreadcrumbs: Crumb[] = [];
 
-        if (segments.length > 0) {
-          for (let i = 0; i < segments.length; i++) {
-            const slug = segments[i];
-            const cat = await fetchCategoryBySlug(slug, parentId);
-            if (!cat) throw new Error(`Category not found: "${slug}"`);
+        for (let index = 0; index < segments.length; index += 1) {
+          const slug = segments[index];
+          const category = await fetchCategoryBySlug(slug, parentId);
+          if (!category) throw new CategoryNotFoundError();
 
-            const pathSoFar = "/catalog/" + segments.slice(0, i + 1).join("/");
-            crumbsTemp.push({ name: cat.name, path: pathSoFar });
+          parentId = category.id;
+          selectedCategory = category;
+          nextBreadcrumbs.push({
+            name: category.name,
+            path: categoryPath(segments.slice(0, index), category.slug),
+          });
+        }
 
-            parentId = cat.id;
-            lastCat = cat;
-          }
-          setCurrentCategory(lastCat);
-        } else {
-          setCurrentCategory(null);
+        const [children, nextProductPage] = await Promise.all([
+          fetchChildCategories(parentId),
+          fetchProductPage({
+            categoryId: parentId ?? undefined,
+            limit: PAGE_SIZE,
+            offset: (currentPage - 1) * PAGE_SIZE,
+            search: searchTerm,
+            sort: apiSort(currentSort),
+          }),
+        ]);
+
+        let navigationCategories = children;
+        let navigationSegments = segments;
+        if (!children.length && selectedCategory?.parentId) {
+          navigationCategories = await fetchChildCategories(selectedCategory.parentId);
+          navigationSegments = segments.slice(0, -1);
         }
 
         if (cancelled) return;
 
-        setBreadcrumbs(crumbsTemp);
-        setCategoriesToShow(await fetchChildCategories(parentId));
-
-        /* Initial product batch */
-        const sortParam = getSortParam(currentSort);
-        const firstProducts = await fetchProducts({
-          categoryId: parentId ?? undefined,
-          sort: sortParam,
-          search: searchTerm,
-          offset: 0,
-          limit: PAGE_SIZE,
-        });
-
+        setBreadcrumbs(nextBreadcrumbs);
+        setCurrentCategory(selectedCategory);
+        setCategoryItems(
+          navigationCategories.map((category) => ({
+            id: category.id,
+            isActive: category.id === selectedCategory?.id,
+            name: category.name,
+            to: categoryPath(navigationSegments, category.slug),
+          }))
+        );
+        setProductPage(nextProductPage);
+      } catch (loadError) {
         if (cancelled) return;
-
-        setProducts(firstProducts);
-        setOffset(firstProducts.length); // might be < PAGE_SIZE
-        setHasMore(firstProducts.length === PAGE_SIZE);
-      } catch (err) {
-        if (cancelled) return;
-        console.error(err);
-        if (axios.isAxiosError(err)) setError(err.response?.data?.message ?? err.message);
-        else if (err instanceof Error) setError(err.message);
-        else setError(String(err));
+        if (loadError instanceof CategoryNotFoundError) setCategoryNotFound(true);
+        else setError(loadError instanceof Error ? loadError.message : "Unable to load the catalog.");
       } finally {
-        if (!cancelled) setLoading(false);
+        if (!cancelled) setIsLoading(false);
       }
     };
 
-    loadInitial();
+    void loadCatalog();
 
     return () => {
       cancelled = true;
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [location.pathname, location.search, currentSort]);
+  }, [currentPage, currentSort, reloadKey, searchTerm, segments]);
 
-  const loadMoreProducts = async () => {
-    if (isLoadingMore || !hasMore) return;
-    setIsLoadingMore(true);
-
-    try {
-      const sortParam = getSortParam(currentSort);
-      const nextOffset = offset;
-      const more = await fetchProducts({
-        categoryId: currentCategory?.id,
-        sort: sortParam,
-        search: searchTerm,
-        offset: nextOffset,
-        limit: PAGE_SIZE,
-      });
-
-      setProducts((prev) => {
-        const existingIds = new Set(prev.map((p) => p.id));
-        const newUnique = more.filter((p) => !existingIds.has(p.id));
-        return [...prev, ...newUnique];
-      });
-
-      setOffset(nextOffset + more.length);
-      setHasMore(more.length === PAGE_SIZE);
-    } catch (err) {
-      console.error("Error loading more:", err);
-    } finally {
-      setIsLoadingMore(false);
-    }
+  const updatePage = (page: number) => {
+    const nextParams = new URLSearchParams(searchParams);
+    if (page === 1) nextParams.delete("page");
+    else nextParams.set("page", String(page));
+    setSearchParams(nextParams);
   };
 
-  if (error) return <NotFoundPage />;
+  const updateSort = (sort: SortOption) => {
+    const nextParams = new URLSearchParams(searchParams);
+    if (sort === "default") nextParams.delete("sort");
+    else nextParams.set("sort", sort);
+    nextParams.delete("page");
+    setSearchParams(nextParams);
+  };
 
-  if (loading)
-    return (
-      <div className="loading">
-        <img src="/images/loading.gif" alt="Loading..." />
-      </div>
-    );
+  if (categoryNotFound) return <NotFoundPage />;
 
-  const isRoot = segments.length === 0;
-  const title = searchTerm
-    ? `Search results for “${searchTerm}”`
-    : isRoot
-      ? "All products"
-      : (currentCategory?.name ?? "Loading Category…");
-  const baseCatalogPath = segments.length > 0 ? "/catalog/" + segments.join("/") : "/catalog/";
+  const title = searchTerm ? `Search results for “${searchTerm}”` : (currentCategory?.name ?? "All products");
 
-  const sidebarContent = (
-    <>
-      {categoriesToShow.length > 0 && (
-        <div className="category-list">
-          {categoriesToShow.map((cat) => {
-            const nextURL = isRoot ? `/catalog/${cat.slug}` : `${baseCatalogPath}/${cat.slug}`;
-            return (
-              <Link
-                key={cat.id}
-                text={cat.name}
-                className="category-link"
-                href=""
-                onClick={(e) => {
-                  e.preventDefault();
-                  setIsMobileFilterOpen(false);
-                  navigate(nextURL);
-                }}
-              />
-            );
-          })}
-        </div>
-      )}
-      <div className="filters">
-        <strong>Filters (placeholder)</strong>
-      </div>
-    </>
-  );
   return (
-    <div className="category-page">
+    <PageContainer className="category-page">
       <Breadcrumbs crumbs={breadcrumbs} />
-      <div className="category-content">
-        <div className="category-subcats-filter">{sidebarContent}</div>
-        <div className="category-content-colomn">
-          <div className="category-title-sort">
-            <H3 text={title} />
-            <Sorting currentSort={currentSort} onSortChange={(s) => setCurrentSort(s)} />
-            <button
-              className="mobile-filter-toggle"
-              onClick={() => setIsMobileFilterOpen(true)}
-              aria-label="Open Filters"
-            >
-              <IoMdOptions size={24} />
-            </button>
-          </div>
-          {products.length === 0 ? (
-            <Paragraph
-              className="no-products"
-              text={
-                searchTerm
-                  ? `No products found for “${searchTerm}”.`
-                  : isRoot
-                    ? "No products available."
-                    : "No products in this category yet."
-              }
-            />
-          ) : (
-            <>
-              <ProductList products={products} className="category-products" />
 
-              {hasMore ? (
-                <div className="load-more-wrapper">
-                  <button className="btn btn-medium load-more-btn" onClick={loadMoreProducts} disabled={isLoadingMore}>
-                    {isLoadingMore ? "Loading..." : "See more"}
-                  </button>
-                </div>
-              ) : (
-                <p className="no-more-products">You’ve reached the end ✨</p>
-              )}
+      <div className="category-page__layout">
+        <aside className="category-page__sidebar">
+          <CategoryFilter items={categoryItems} />
+        </aside>
+
+        <main aria-labelledby="catalog-title" className="category-page__main">
+          <header className="category-page__toolbar">
+            <div className="category-page__heading">
+              <h1 id="catalog-title">{title}</h1>
+              <p>{isLoading ? "Loading products…" : pageSummary(productPage)}</p>
+            </div>
+
+            <Sorting className="category-page__desktop-sort" currentSort={currentSort} onSortChange={updateSort} />
+            <button
+              aria-controls="catalog-options"
+              aria-expanded={isDrawerOpen}
+              aria-label="Open catalog options"
+              className="category-page__filter-toggle"
+              onClick={() => setIsDrawerOpen(true)}
+              type="button"
+            >
+              <PiSlidersHorizontal aria-hidden="true" />
+            </button>
+          </header>
+
+          {isLoading ? (
+            <div aria-live="polite" className="category-page__status" role="status">
+              <span className="category-page__spinner" />
+              Loading products…
+            </div>
+          ) : error ? (
+            <div className="category-page__status" role="alert">
+              <p>{error}</p>
+              <button className="category-page__retry" onClick={() => setReloadKey((key) => key + 1)} type="button">
+                Try again
+              </button>
+            </div>
+          ) : productPage.items.length ? (
+            <>
+              <ProductList className="category-products" products={productPage.items} />
+              <Pagination
+                className="category-page__pagination"
+                currentPage={currentPage}
+                onPageChange={updatePage}
+                pageSize={PAGE_SIZE}
+                totalItems={productPage.total}
+              />
             </>
+          ) : (
+            <div className="category-page__status">
+              <p>{searchTerm ? `No products found for “${searchTerm}”.` : "No products found in this category."}</p>
+            </div>
           )}
-        </div>
+        </main>
       </div>
-      {isMobileFilterOpen && (
-        <div className="mobile-filter-overlay">
-          <button className="close-overlay" onClick={() => setIsMobileFilterOpen(false)} aria-label="Close Filters">
-            <IoMdClose size={28} />
-          </button>
-          <div className="category-subcats-filter-inner">{sidebarContent}</div>
-        </div>
-      )}
-    </div>
+
+      <div id="catalog-options">
+        <FilterDrawer isOpen={isDrawerOpen} onClose={() => setIsDrawerOpen(false)}>
+          <Sorting currentSort={currentSort} onSortChange={updateSort} />
+          <CategoryFilter items={categoryItems} onNavigate={() => setIsDrawerOpen(false)} />
+        </FilterDrawer>
+      </div>
+    </PageContainer>
   );
 }

--- a/frontend/src/services/productService/productService.spec.ts
+++ b/frontend/src/services/productService/productService.spec.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { apiClient } from "../apiClient";
-import { fetchProducts } from "./productService";
+import { fetchProductPage, fetchProducts } from "./productService";
 
 vi.mock("../apiClient", () => ({
   apiClient: { get: vi.fn() },
@@ -40,6 +40,44 @@ describe("productService", () => {
 
     expect(apiClient.get).toHaveBeenCalledWith("/catalog/products", {
       params: { sort: "RELEVANCE", offset: 0, limit: 20 },
+    });
+  });
+
+  it("returns pagination metadata with mapped products", async () => {
+    vi.mocked(apiClient.get).mockResolvedValueOnce({
+      data: {
+        items: [
+          {
+            id: "product-id",
+            slug: "match-football",
+            name: "Match Football",
+            description: null,
+            images: [{ url: "football.jpg", alt: "Match Football" }],
+            price: { amount: 3499, currency: "EUR" },
+            compareAtPrice: { amount: 4499, currency: "EUR" },
+          },
+        ],
+        offset: 6,
+        limit: 6,
+        total: 8,
+      },
+    });
+
+    await expect(fetchProductPage({ offset: 6, limit: 6 })).resolves.toEqual({
+      items: [
+        {
+          id: "product-id",
+          slug: "match-football",
+          name: "Match Football",
+          description: "",
+          imgUrls: ["football.jpg"],
+          currentPrice: 3499,
+          oldPrice: 4499,
+        },
+      ],
+      offset: 6,
+      limit: 6,
+      total: 8,
     });
   });
 });

--- a/frontend/src/services/productService/productService.ts
+++ b/frontend/src/services/productService/productService.ts
@@ -1,5 +1,5 @@
 import { apiClient } from "../apiClient";
-import type { Product } from "./types";
+import type { Product, ProductPage } from "./types";
 
 interface ProductDto {
   id: string;
@@ -53,13 +53,13 @@ export async function fetchProductById(productId: string): Promise<Product | nul
   }
 }
 
-export async function fetchProducts({
+export async function fetchProductPage({
   categoryId,
   sort,
   search,
   offset = 0,
   limit = 20,
-}: ProductListQuery = {}): Promise<Product[]> {
+}: ProductListQuery = {}): Promise<ProductPage> {
   const normalizedSearch = search?.trim();
   const response = await apiClient.get<ProductPageDto>("/catalog/products", {
     params: {
@@ -70,5 +70,14 @@ export async function fetchProducts({
       limit,
     },
   });
-  return response.data.items.map(mapProduct);
+  return {
+    items: response.data.items.map(mapProduct),
+    offset: response.data.offset,
+    limit: response.data.limit,
+    total: response.data.total,
+  };
+}
+
+export async function fetchProducts(query: ProductListQuery = {}): Promise<Product[]> {
+  return (await fetchProductPage(query)).items;
 }

--- a/frontend/src/services/productService/types.ts
+++ b/frontend/src/services/productService/types.ts
@@ -7,3 +7,10 @@ export interface Product {
   currentPrice: number; //in centes
   oldPrice: number; //in centes
 }
+
+export interface ProductPage {
+  items: Product[];
+  offset: number;
+  limit: number;
+  total: number;
+}


### PR DESCRIPTION
## Summary

Redesigns the catalog around the saved desktop and mobile Figma references while keeping every visible control backed by the real NestJS catalog API.

## What changed

### Catalog API
- parent-category filtering now includes products assigned to descendant categories
- supports nested category trees without duplicating parent assignments in seed data
- adds unit coverage for multi-level category scopes

### Catalog data flow
- adds `fetchProductPage()` with `items`, `offset`, `limit`, and `total`
- preserves the existing `fetchProducts()` array API for Home and other consumers
- moves catalog sorting and page number into shareable URL parameters

### Storefront components
- adds accessible server pagination with Previous/Next, page numbers, and `aria-current`
- replaces the custom sorting dropdown with a native accessible select
- adds a real category filter panel
- adds a mobile catalog drawer with Escape/backdrop closing and scroll locking
- upgrades breadcrumbs to semantic navigation
- uses unique generated labels when desktop and mobile filters coexist

### Responsive catalog
- implements a 3-column desktop, 2-column tablet/mobile product grid
- adds real result ranges such as `Showing 1-6 of 8 products`
- adds loading, empty, error/retry, and category-not-found states
- keeps Add to Cart available from catalog cards
- intentionally omits unsupported color, size, rating, and price-range filters instead of presenting placeholders

## Validation

- `npm run format:check`
- `npm run lint`
- frontend: 35 test files, 60 tests passed
- backend: 7 test files, 17 tests passed
- frontend and backend production builds passed
- Playwright store smoke passed
- backend API e2e passed
- desktop QA at 1280 px: 3-column grid, no horizontal overflow
- mobile QA at 390 px: 2-column grid, drawer, sorting, category navigation, and pagination verified
- verified `Balls` returns products assigned to Football and Basketball descendants
