### PR TITLE
feat(storefront): redesign responsive product details

### DIFF
--- a/e2e/store.spec.ts
+++ b/e2e/store.spec.ts
@@ -35,3 +35,22 @@ test("registers, shops with a promo code, opens profile and logs out", async ({ 
   await expect(page).toHaveURL(/\/login$/);
   await expect(page.getByRole("heading", { name: "Login" })).toBeVisible();
 });
+
+test("opens a product and adds the selected quantity", async ({ page }) => {
+  await page.goto("/catalog");
+  await page
+    .getByRole("link", { name: /^View / })
+    .first()
+    .click();
+
+  await expect(page).toHaveURL(/\/product\/[0-9a-f-]+$/);
+  await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+
+  await page.getByRole("button", { name: "Increase quantity" }).click();
+  await page.getByRole("button", { name: "Increase quantity" }).click();
+  await expect(page.getByRole("status", { name: "Quantity" })).toHaveText("3");
+
+  await page.getByRole("button", { name: "Add to Cart" }).click();
+  await expect(page.getByText(/3 × .+ added to your cart\./)).toBeVisible();
+  await expect(page.getByRole("link", { name: "Shopping cart, 3 items" })).toBeVisible();
+});

--- a/frontend/src/components/Home/HomeProductSection/HomeProductSection.spec.tsx
+++ b/frontend/src/components/Home/HomeProductSection/HomeProductSection.spec.tsx
@@ -20,6 +20,7 @@ const products: Product[] = [
     slug: "running-shoes",
     name: "Running Shoes",
     imgUrls: ["/shoes.jpg"],
+    categoryIds: ["shoes"],
     currentPrice: 7999,
     oldPrice: 9999,
   },

--- a/frontend/src/components/Product/ProductGallery/ProductGallery.scss
+++ b/frontend/src/components/Product/ProductGallery/ProductGallery.scss
@@ -1,0 +1,145 @@
+@use "../../../assets/styles/tokens" as *;
+
+.product-gallery {
+  display: grid;
+  min-width: 0;
+  grid-template-columns: 15.2rem minmax(0, 1fr);
+  grid-template-rows: minmax(0, 53rem);
+  gap: var(--space-4);
+}
+
+.product-gallery__thumbnails {
+  display: grid;
+  align-content: start;
+  gap: var(--space-4);
+  overflow-y: auto;
+}
+
+.product-gallery__thumbnail,
+.product-gallery__main {
+  display: block;
+  padding: 0;
+  overflow: hidden;
+  border: 0;
+  background: var(--color-surface-subtle);
+  cursor: pointer;
+}
+
+.product-gallery__thumbnail {
+  width: 100%;
+  aspect-ratio: 1;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+
+  &[aria-pressed="true"] {
+    border-color: var(--color-ink);
+  }
+
+  &:focus-visible {
+    outline: none;
+    box-shadow: var(--shadow-focus);
+  }
+}
+
+.product-gallery__main {
+  width: 100%;
+  height: 100%;
+  border-radius: var(--radius-md);
+
+  &:focus-visible {
+    outline: none;
+    box-shadow: var(--shadow-focus);
+  }
+}
+
+.product-gallery img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.product-gallery__dialog {
+  position: fixed;
+  z-index: 1100;
+  display: grid;
+  padding: var(--space-6);
+  inset: 0;
+  place-items: center;
+  background: rgb(0 0 0 / 78%);
+}
+
+.product-gallery__dialog-content {
+  position: relative;
+  width: min(90vw, 90rem);
+  height: min(88vh, 90rem);
+  padding: var(--space-5);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+}
+
+.product-gallery__dialog-content > img {
+  object-fit: contain;
+}
+
+.product-gallery__close {
+  position: absolute;
+  z-index: 1;
+  top: var(--space-3);
+  right: var(--space-3);
+  display: grid;
+  width: 4.4rem;
+  height: 4.4rem;
+  padding: 0;
+  place-items: center;
+  border: 0;
+  border-radius: 50%;
+  background: var(--color-surface);
+  box-shadow: 0 0.4rem 1.2rem rgb(0 0 0 / 18%);
+  cursor: pointer;
+  font-size: var(--font-size-xl);
+}
+
+@media (max-width: 900px) {
+  .product-gallery {
+    grid-template-columns: 11rem minmax(0, 1fr);
+    grid-template-rows: minmax(0, 44rem);
+  }
+}
+
+@media (max-width: $breakpoint-mobile) {
+  .product-gallery {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-template-rows: auto auto;
+    gap: var(--space-3);
+  }
+
+  .product-gallery__main {
+    grid-column: 1 / -1;
+    grid-row: 1;
+    aspect-ratio: 1.1;
+  }
+
+  .product-gallery__thumbnails {
+    display: grid;
+    overflow: visible;
+    grid-column: 1 / -1;
+    grid-row: 2;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: var(--space-2);
+  }
+
+  .product-gallery__thumbnail:nth-child(n + 4) {
+    display: none;
+  }
+
+  .product-gallery__dialog {
+    padding: var(--space-3);
+  }
+
+  .product-gallery__dialog-content {
+    width: 100%;
+    height: min(80vh, 60rem);
+    padding: var(--space-3);
+  }
+}

--- a/frontend/src/components/Product/ProductGallery/ProductGallery.scss
+++ b/frontend/src/components/Product/ProductGallery/ProductGallery.scss
@@ -8,6 +8,10 @@
   gap: var(--space-4);
 }
 
+.product-gallery--single {
+  grid-template-columns: minmax(0, 1fr);
+}
+
 .product-gallery__thumbnails {
   display: grid;
   align-content: start;
@@ -104,6 +108,10 @@
   .product-gallery {
     grid-template-columns: 11rem minmax(0, 1fr);
     grid-template-rows: minmax(0, 44rem);
+  }
+
+  .product-gallery--single {
+    grid-template-columns: minmax(0, 1fr);
   }
 }
 

--- a/frontend/src/components/Product/ProductGallery/ProductGallery.spec.tsx
+++ b/frontend/src/components/Product/ProductGallery/ProductGallery.spec.tsx
@@ -1,0 +1,26 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ProductGallery } from "./ProductGallery";
+
+describe("ProductGallery", () => {
+  it("changes the active image from an accessible thumbnail", () => {
+    render(<ProductGallery images={["front.jpg", "back.jpg"]} productName="Training shirt" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "View Training shirt image 2" }));
+
+    expect(screen.getByRole("button", { name: "View Training shirt image 2" })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("img", { name: "Training shirt, image 2 of 2" })).toHaveAttribute("src", "back.jpg");
+  });
+
+  it("opens an enlarged image and closes it with Escape", () => {
+    render(<ProductGallery images={["shirt.jpg"]} productName="Training shirt" />);
+
+    expect(screen.queryByRole("button", { name: /View Training shirt image/ })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Expand Training shirt, image 1 of 1" }));
+    expect(screen.getByRole("dialog", { name: "Training shirt enlarged image" })).toBeVisible();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/Product/ProductGallery/ProductGallery.spec.tsx
+++ b/frontend/src/components/Product/ProductGallery/ProductGallery.spec.tsx
@@ -14,8 +14,9 @@ describe("ProductGallery", () => {
   });
 
   it("opens an enlarged image and closes it with Escape", () => {
-    render(<ProductGallery images={["shirt.jpg"]} productName="Training shirt" />);
+    const { container } = render(<ProductGallery images={["shirt.jpg"]} productName="Training shirt" />);
 
+    expect(container.firstChild).toHaveClass("product-gallery--single");
     expect(screen.queryByRole("button", { name: /View Training shirt image/ })).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Expand Training shirt, image 1 of 1" }));
     expect(screen.getByRole("dialog", { name: "Training shirt enlarged image" })).toBeVisible();

--- a/frontend/src/components/Product/ProductGallery/ProductGallery.tsx
+++ b/frontend/src/components/Product/ProductGallery/ProductGallery.tsx
@@ -37,9 +37,10 @@ export function ProductGallery({ images, productName }: ProductGalleryProps) {
 
   const activeImage = galleryImages[activeIndex] ?? galleryImages[0];
   const imageLabel = `${productName}, image ${activeIndex + 1} of ${galleryImages.length}`;
+  const galleryClassName = `product-gallery${galleryImages.length === 1 ? " product-gallery--single" : ""}`;
 
   return (
-    <section aria-label={`${productName} images`} className="product-gallery">
+    <section aria-label={`${productName} images`} className={galleryClassName}>
       {galleryImages.length > 1 && (
         <div className="product-gallery__thumbnails">
           {galleryImages.map((image, index) => (

--- a/frontend/src/components/Product/ProductGallery/ProductGallery.tsx
+++ b/frontend/src/components/Product/ProductGallery/ProductGallery.tsx
@@ -1,0 +1,100 @@
+import { useEffect, useState } from "react";
+import { PiX } from "react-icons/pi";
+
+import "./ProductGallery.scss";
+
+type ProductGalleryProps = {
+  images: string[];
+  productName: string;
+};
+
+const FALLBACK_IMAGE = "/images/loading.gif";
+
+export function ProductGallery({ images, productName }: ProductGalleryProps) {
+  const galleryImages = images.length ? images : [FALLBACK_IMAGE];
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  useEffect(() => {
+    setActiveIndex(0);
+  }, [productName]);
+
+  useEffect(() => {
+    if (!isExpanded) return;
+
+    const previousOverflow = document.body.style.overflow;
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setIsExpanded(false);
+    };
+
+    document.body.style.overflow = "hidden";
+    document.addEventListener("keydown", closeOnEscape);
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      document.removeEventListener("keydown", closeOnEscape);
+    };
+  }, [isExpanded]);
+
+  const activeImage = galleryImages[activeIndex] ?? galleryImages[0];
+  const imageLabel = `${productName}, image ${activeIndex + 1} of ${galleryImages.length}`;
+
+  return (
+    <section aria-label={`${productName} images`} className="product-gallery">
+      {galleryImages.length > 1 && (
+        <div className="product-gallery__thumbnails">
+          {galleryImages.map((image, index) => (
+            <button
+              aria-label={`View ${productName} image ${index + 1}`}
+              aria-pressed={activeIndex === index}
+              className="product-gallery__thumbnail"
+              key={`${image}-${index}`}
+              onClick={() => setActiveIndex(index)}
+              type="button"
+            >
+              <img alt="" src={image} />
+            </button>
+          ))}
+        </div>
+      )}
+
+      <button
+        aria-label={`Expand ${imageLabel}`}
+        className="product-gallery__main"
+        onClick={() => setIsExpanded(true)}
+        type="button"
+      >
+        <img
+          alt={imageLabel}
+          onError={(event) => {
+            event.currentTarget.src = FALLBACK_IMAGE;
+          }}
+          src={activeImage}
+        />
+      </button>
+
+      {isExpanded && (
+        <div
+          aria-label={`${productName} enlarged image`}
+          aria-modal="true"
+          className="product-gallery__dialog"
+          onClick={(event) => {
+            if (event.currentTarget === event.target) setIsExpanded(false);
+          }}
+          role="dialog"
+        >
+          <div className="product-gallery__dialog-content">
+            <button
+              aria-label="Close enlarged image"
+              className="product-gallery__close"
+              onClick={() => setIsExpanded(false)}
+              type="button"
+            >
+              <PiX aria-hidden="true" />
+            </button>
+            <img alt={imageLabel} src={activeImage} />
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/Product/ProductPurchasePanel/ProductPurchasePanel.scss
+++ b/frontend/src/components/Product/ProductPurchasePanel/ProductPurchasePanel.scss
@@ -1,0 +1,101 @@
+@use "../../../assets/styles/tokens" as *;
+
+.product-purchase-panel {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+}
+
+.product-purchase-panel h1 {
+  margin: 0;
+  color: var(--color-ink);
+  font-family: var(--font-family-heading);
+  font-size: var(--font-size-3xl);
+  font-weight: var(--font-weight-bold);
+  line-height: var(--line-height-heading);
+}
+
+.product-purchase-panel__prices {
+  display: flex;
+  margin-top: var(--space-5);
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+}
+
+.product-purchase-panel__current-price,
+.product-purchase-panel__old-price {
+  font-size: var(--font-size-2xl);
+  font-weight: var(--font-weight-bold);
+  line-height: var(--line-height-heading);
+}
+
+.product-purchase-panel__old-price {
+  color: var(--color-text-subtle);
+  text-decoration: line-through;
+}
+
+.product-purchase-panel__discount {
+  padding: 0.6rem var(--space-4);
+  border-radius: var(--radius-pill);
+  background: rgb(255 51 51 / 10%);
+  color: var(--color-danger);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+}
+
+.product-purchase-panel__description {
+  margin-top: var(--space-5);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-md);
+  line-height: var(--line-height-relaxed);
+}
+
+.product-purchase-panel__actions {
+  display: flex;
+  margin-top: var(--space-6);
+  padding-top: var(--space-6);
+  align-items: stretch;
+  gap: var(--space-5);
+  border-top: var(--border-subtle);
+}
+
+.product-purchase-panel__add {
+  min-height: 5.2rem;
+  flex: 1;
+}
+
+@media (max-width: $breakpoint-mobile) {
+  .product-purchase-panel h1 {
+    font-size: var(--font-size-xl);
+  }
+
+  .product-purchase-panel__prices {
+    margin-top: var(--space-3);
+  }
+
+  .product-purchase-panel__current-price,
+  .product-purchase-panel__old-price {
+    font-size: var(--font-size-xl);
+  }
+
+  .product-purchase-panel__discount {
+    padding: var(--space-1) var(--space-3);
+    font-size: var(--font-size-xs);
+  }
+
+  .product-purchase-panel__description {
+    margin-top: var(--space-3);
+    font-size: var(--font-size-sm);
+  }
+
+  .product-purchase-panel__actions {
+    margin-top: var(--space-4);
+    padding-top: var(--space-4);
+    gap: var(--space-3);
+  }
+
+  .product-purchase-panel__add {
+    min-height: 4.4rem;
+  }
+}

--- a/frontend/src/components/Product/ProductPurchasePanel/ProductPurchasePanel.spec.tsx
+++ b/frontend/src/components/Product/ProductPurchasePanel/ProductPurchasePanel.spec.tsx
@@ -1,0 +1,54 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Product } from "../../../services/productService/types";
+import { useCart } from "../../context/useCart";
+import { ProductPurchasePanel } from "./ProductPurchasePanel";
+
+vi.mock("../../context/useCart", () => ({ useCart: vi.fn() }));
+
+const product: Product = {
+  id: "product-id",
+  slug: "match-football",
+  name: "Match Football",
+  description: "Competition-ready football.",
+  imgUrls: ["football.jpg"],
+  categoryIds: ["football-id"],
+  currentPrice: 3499,
+  oldPrice: 4499,
+};
+
+describe("ProductPurchasePanel", () => {
+  const addToCart = vi.fn();
+
+  beforeEach(() => {
+    addToCart.mockReset();
+    addToCart.mockResolvedValue(undefined);
+    vi.mocked(useCart).mockReturnValue({ addToCart } as never);
+  });
+
+  it("presents product pricing and adds the selected quantity", async () => {
+    render(<ProductPurchasePanel product={product} />);
+
+    expect(screen.getByRole("heading", { name: "Match Football" })).toBeVisible();
+    expect(screen.getByLabelText("Product price")).toHaveTextContent("€34.99");
+    expect(screen.getByLabelText("Product price")).toHaveTextContent("-22%");
+
+    fireEvent.click(screen.getByRole("button", { name: "Increase quantity" }));
+    fireEvent.click(screen.getByRole("button", { name: "Add to Cart" }));
+
+    await waitFor(() => expect(addToCart).toHaveBeenCalledWith("product-id", 2));
+    expect(await screen.findByText("2 × Match Football added to your cart.")).toBeVisible();
+  });
+
+  it("reports a cart failure without losing the selected quantity", async () => {
+    addToCart.mockRejectedValueOnce(new Error("Unavailable"));
+    render(<ProductPurchasePanel product={product} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Increase quantity" }));
+    fireEvent.click(screen.getByRole("button", { name: "Add to Cart" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("couldn't add this product");
+    expect(screen.getByRole("status", { name: "Quantity" })).toHaveTextContent("2");
+  });
+});

--- a/frontend/src/components/Product/ProductPurchasePanel/ProductPurchasePanel.tsx
+++ b/frontend/src/components/Product/ProductPurchasePanel/ProductPurchasePanel.tsx
@@ -1,0 +1,84 @@
+import { useState } from "react";
+
+import type { Product } from "../../../services/productService/types";
+import Button from "../../common/button/button";
+import Message from "../../common/message/Message";
+import { useCart } from "../../context/useCart";
+import { QuantitySelector } from "../QuantitySelector/QuantitySelector";
+
+import "./ProductPurchasePanel.scss";
+
+type ProductPurchasePanelProps = {
+  product: Product;
+};
+
+const moneyFormatter = new Intl.NumberFormat("en-IE", {
+  style: "currency",
+  currency: "EUR",
+});
+
+export function ProductPurchasePanel({ product }: ProductPurchasePanelProps) {
+  const { addToCart } = useCart();
+  const [quantity, setQuantity] = useState(1);
+  const [isAdding, setIsAdding] = useState(false);
+  const [feedback, setFeedback] = useState<{ text: string; variant: "error" | "success" } | null>(null);
+
+  const hasDiscount = product.oldPrice > product.currentPrice;
+  const discount = hasDiscount ? Math.round(((product.oldPrice - product.currentPrice) / product.oldPrice) * 100) : 0;
+
+  const addProduct = async () => {
+    setIsAdding(true);
+    setFeedback(null);
+    try {
+      await addToCart(product.id, quantity);
+      setFeedback({
+        text: `${quantity} × ${product.name} added to your cart.`,
+        variant: "success",
+      });
+      setQuantity(1);
+    } catch {
+      setFeedback({ text: "We couldn't add this product. Please try again.", variant: "error" });
+    } finally {
+      setIsAdding(false);
+    }
+  };
+
+  return (
+    <section aria-labelledby="product-title" className="product-purchase-panel">
+      <h1 id="product-title">{product.name}</h1>
+
+      <div aria-label="Product price" className="product-purchase-panel__prices">
+        <span className="product-purchase-panel__current-price">
+          {moneyFormatter.format(product.currentPrice / 100)}
+        </span>
+        {hasDiscount && (
+          <>
+            <span
+              aria-label={`Previous price ${moneyFormatter.format(product.oldPrice / 100)}`}
+              className="product-purchase-panel__old-price"
+            >
+              {moneyFormatter.format(product.oldPrice / 100)}
+            </span>
+            <span className="product-purchase-panel__discount">-{discount}%</span>
+          </>
+        )}
+      </div>
+
+      <p className="product-purchase-panel__description">
+        {product.description || "Product details will be available soon."}
+      </p>
+
+      <div className="product-purchase-panel__actions">
+        <QuantitySelector disabled={isAdding} onChange={setQuantity} value={quantity} />
+        <Button
+          className="product-purchase-panel__add"
+          disabled={isAdding}
+          onClick={() => void addProduct()}
+          text={isAdding ? "Adding…" : "Add to Cart"}
+        />
+      </div>
+
+      {feedback && <Message onClose={() => setFeedback(null)} text={feedback.text} variant={feedback.variant} />}
+    </section>
+  );
+}

--- a/frontend/src/components/Product/QuantitySelector/QuantitySelector.scss
+++ b/frontend/src/components/Product/QuantitySelector/QuantitySelector.scss
@@ -1,0 +1,63 @@
+@use "../../../assets/styles/tokens" as *;
+
+.quantity-selector {
+  display: grid;
+  min-width: 17rem;
+  min-height: 5.2rem;
+  padding: 0 var(--space-4);
+  align-items: center;
+  grid-template-columns: 4rem 1fr 4rem;
+  border-radius: var(--radius-pill);
+  background: var(--color-surface-subtle);
+}
+
+.quantity-selector button {
+  display: grid;
+  width: 4rem;
+  height: 4rem;
+  padding: 0;
+  place-items: center;
+  border: 0;
+  border-radius: 50%;
+  background: transparent;
+  color: var(--color-ink);
+  cursor: pointer;
+  font-size: var(--font-size-xl);
+  transition: background var(--transition-fast);
+
+  &:hover:not(:disabled) {
+    background: rgb(0 0 0 / 7%);
+  }
+
+  &:focus-visible {
+    outline: none;
+    box-shadow: var(--shadow-focus);
+  }
+
+  &:disabled {
+    color: var(--color-text-subtle);
+    cursor: not-allowed;
+  }
+}
+
+.quantity-selector output {
+  color: var(--color-ink);
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-medium);
+  text-align: center;
+}
+
+@media (max-width: $breakpoint-mobile) {
+  .quantity-selector {
+    min-width: 11rem;
+    min-height: 4.4rem;
+    padding: 0 var(--space-2);
+    grid-template-columns: 3.2rem 1fr 3.2rem;
+  }
+
+  .quantity-selector button {
+    width: 3.2rem;
+    height: 3.2rem;
+    font-size: var(--font-size-lg);
+  }
+}

--- a/frontend/src/components/Product/QuantitySelector/QuantitySelector.spec.tsx
+++ b/frontend/src/components/Product/QuantitySelector/QuantitySelector.spec.tsx
@@ -1,0 +1,27 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { QuantitySelector } from "./QuantitySelector";
+
+describe("QuantitySelector", () => {
+  it("requests quantity changes within its limits", () => {
+    const onChange = vi.fn();
+    const { rerender } = render(<QuantitySelector onChange={onChange} value={2} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Decrease quantity" }));
+    fireEvent.click(screen.getByRole("button", { name: "Increase quantity" }));
+
+    expect(onChange).toHaveBeenNthCalledWith(1, 1);
+    expect(onChange).toHaveBeenNthCalledWith(2, 3);
+
+    rerender(<QuantitySelector max={3} onChange={onChange} value={3} />);
+    expect(screen.getByRole("button", { name: "Increase quantity" })).toBeDisabled();
+  });
+
+  it("does not allow a quantity below one", () => {
+    render(<QuantitySelector onChange={vi.fn()} value={1} />);
+
+    expect(screen.getByRole("button", { name: "Decrease quantity" })).toBeDisabled();
+    expect(screen.getByRole("status", { name: "Quantity" })).toHaveTextContent("1");
+  });
+});

--- a/frontend/src/components/Product/QuantitySelector/QuantitySelector.tsx
+++ b/frontend/src/components/Product/QuantitySelector/QuantitySelector.tsx
@@ -1,0 +1,47 @@
+import { PiMinus, PiPlus } from "react-icons/pi";
+
+import "./QuantitySelector.scss";
+
+type QuantitySelectorProps = {
+  value: number;
+  onChange: (value: number) => void;
+  min?: number;
+  max?: number;
+  disabled?: boolean;
+  className?: string;
+};
+
+export function QuantitySelector({
+  value,
+  onChange,
+  min = 1,
+  max = 99,
+  disabled = false,
+  className = "",
+}: QuantitySelectorProps) {
+  const selectorClassName = `quantity-selector ${className}`.trim();
+
+  return (
+    <div aria-label="Product quantity" className={selectorClassName} role="group">
+      <button
+        aria-label="Decrease quantity"
+        disabled={disabled || value <= min}
+        onClick={() => onChange(Math.max(min, value - 1))}
+        type="button"
+      >
+        <PiMinus aria-hidden="true" />
+      </button>
+      <output aria-live="polite" aria-label="Quantity">
+        {value}
+      </output>
+      <button
+        aria-label="Increase quantity"
+        disabled={disabled || value >= max}
+        onClick={() => onChange(Math.min(max, value + 1))}
+        type="button"
+      >
+        <PiPlus aria-hidden="true" />
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/Product/RelatedProducts/RelatedProducts.scss
+++ b/frontend/src/components/Product/RelatedProducts/RelatedProducts.scss
@@ -1,0 +1,47 @@
+@use "../../../assets/styles/tokens" as *;
+
+.related-products {
+  padding-top: var(--space-20);
+}
+
+.related-products h2 {
+  margin: 0 0 var(--space-12);
+  color: var(--color-ink);
+  font-family: var(--font-family-heading);
+  font-size: var(--font-size-4xl);
+  font-weight: var(--font-weight-bold);
+  line-height: var(--line-height-heading);
+  text-align: center;
+}
+
+.related-products__list {
+  display: grid;
+  align-items: stretch;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: var(--space-5);
+
+  .product-list__item {
+    width: 100%;
+  }
+}
+
+@media (max-width: 900px) {
+  .related-products__list {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: $breakpoint-mobile) {
+  .related-products {
+    padding-top: var(--space-16);
+  }
+
+  .related-products h2 {
+    margin-bottom: var(--space-8);
+    font-size: var(--font-size-2xl);
+  }
+
+  .related-products__list {
+    gap: var(--space-4);
+  }
+}

--- a/frontend/src/components/Product/RelatedProducts/RelatedProducts.spec.tsx
+++ b/frontend/src/components/Product/RelatedProducts/RelatedProducts.spec.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { Product } from "../../../services/productService/types";
+import { RelatedProducts } from "./RelatedProducts";
+
+vi.mock("../../productList/ProductList", () => ({
+  default: ({ products, variant }: { products: Product[]; variant: string }) => (
+    <ul aria-label="Recommendations" data-variant={variant}>
+      {products.map((product) => (
+        <li key={product.id}>{product.name}</li>
+      ))}
+    </ul>
+  ),
+}));
+
+function product(index: number): Product {
+  return {
+    id: `product-${index}`,
+    slug: `product-${index}`,
+    name: `Product ${index}`,
+    imgUrls: [],
+    categoryIds: ["category-id"],
+    currentPrice: 1000,
+    oldPrice: 1000,
+  };
+}
+
+describe("RelatedProducts", () => {
+  it("excludes the current product and limits the storefront row to four items", () => {
+    render(
+      <RelatedProducts currentProductId="product-1" products={Array.from({ length: 6 }, (_, i) => product(i + 1))} />
+    );
+
+    expect(screen.getByRole("heading", { name: "You might also like" })).toBeVisible();
+    expect(screen.queryByText("Product 1")).not.toBeInTheDocument();
+    expect(screen.getAllByRole("listitem")).toHaveLength(4);
+    expect(screen.getByRole("list", { name: "Recommendations" })).toHaveAttribute("data-variant", "showcase");
+  });
+
+  it("does not render an empty recommendations section", () => {
+    const { container } = render(<RelatedProducts currentProductId="product-1" products={[product(1)]} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/frontend/src/components/Product/RelatedProducts/RelatedProducts.tsx
+++ b/frontend/src/components/Product/RelatedProducts/RelatedProducts.tsx
@@ -1,0 +1,21 @@
+import type { Product } from "../../../services/productService/types";
+import ProductList from "../../productList/ProductList";
+
+import "./RelatedProducts.scss";
+
+type RelatedProductsProps = {
+  currentProductId: string;
+  products: Product[];
+};
+
+export function RelatedProducts({ currentProductId, products }: RelatedProductsProps) {
+  const relatedProducts = products.filter((product) => product.id !== currentProductId).slice(0, 4);
+  if (!relatedProducts.length) return null;
+
+  return (
+    <section aria-labelledby="related-products-title" className="related-products">
+      <h2 id="related-products-title">You might also like</h2>
+      <ProductList className="related-products__list" products={relatedProducts} variant="showcase" />
+    </section>
+  );
+}

--- a/frontend/src/components/context/CartContext.tsx
+++ b/frontend/src/components/context/CartContext.tsx
@@ -3,7 +3,7 @@ import type { CartResponse } from "../../services/cartService/types";
 
 export interface CartContextType {
   cart: CartResponse | null;
-  addToCart: (productId: string) => Promise<void>;
+  addToCart: (productId: string, quantity?: number) => Promise<void>;
   removeFromCart: (productId: string, quantity?: number) => Promise<void>;
   calculateTotalQuantity: () => number;
   applyPromoCode: (promoCode: string) => Promise<void>;

--- a/frontend/src/components/context/CartContextProvider.spec.tsx
+++ b/frontend/src/components/context/CartContextProvider.spec.tsx
@@ -1,0 +1,74 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  addCartItem,
+  applyDiscountCode,
+  clearCart,
+  deleteCartItem,
+  getCart,
+  updateCartItem,
+} from "../../services/cartService/cartService";
+import type { CartResponse } from "../../services/cartService/types";
+import { CartDataProvider } from "./CartContextProvider";
+import { useCart } from "./useCart";
+
+vi.mock("../../services/cartService/cartService", () => ({
+  addCartItem: vi.fn(),
+  applyDiscountCode: vi.fn(),
+  clearCart: vi.fn(),
+  deleteCartItem: vi.fn(),
+  getCart: vi.fn(),
+  updateCartItem: vi.fn(),
+}));
+
+const emptyCart: CartResponse = {
+  id: "cart-id",
+  items: [],
+  totalQuantity: 0,
+  subtotal: { amount: 0, currency: "EUR" },
+  discount: { amount: 0, currency: "EUR" },
+  total: { amount: 0, currency: "EUR" },
+  discountCode: null,
+};
+
+function CartProbe() {
+  const { addToCart, calculateTotalQuantity } = useCart();
+  return (
+    <>
+      <output aria-label="Cart quantity">{calculateTotalQuantity()}</output>
+      <button onClick={() => void addToCart("product-id", 3)} type="button">
+        Add three
+      </button>
+    </>
+  );
+}
+
+describe("CartDataProvider", () => {
+  beforeEach(() => {
+    vi.mocked(getCart).mockReset();
+    vi.mocked(addCartItem).mockReset();
+    vi.mocked(applyDiscountCode).mockReset();
+    vi.mocked(clearCart).mockReset();
+    vi.mocked(deleteCartItem).mockReset();
+    vi.mocked(updateCartItem).mockReset();
+    vi.mocked(getCart).mockResolvedValue(emptyCart);
+  });
+
+  it("adds the selected product quantity and stores the returned cart", async () => {
+    const updatedCart = { ...emptyCart, totalQuantity: 3 };
+    vi.mocked(addCartItem).mockResolvedValue(updatedCart);
+
+    render(
+      <CartDataProvider>
+        <CartProbe />
+      </CartDataProvider>
+    );
+
+    await waitFor(() => expect(getCart).toHaveBeenCalledOnce());
+    fireEvent.click(screen.getByRole("button", { name: "Add three" }));
+
+    await waitFor(() => expect(addCartItem).toHaveBeenCalledWith("product-id", 3));
+    expect(screen.getByRole("status", { name: "Cart quantity" })).toHaveTextContent("3");
+  });
+});

--- a/frontend/src/components/context/CartContextProvider.tsx
+++ b/frontend/src/components/context/CartContextProvider.tsx
@@ -21,7 +21,7 @@ export function CartDataProvider({ children }: { children: React.ReactNode }) {
     void refreshCart();
   }, [refreshCart]);
 
-  const addToCart = async (productId: string) => setCart(await addCartItem(productId));
+  const addToCart = async (productId: string, quantity = 1) => setCart(await addCartItem(productId, quantity));
 
   const removeFromCart = async (productId: string, quantity?: number) => {
     if (!cart) throw new Error("Cart not initialized");

--- a/frontend/src/pages/Category/Category.spec.tsx
+++ b/frontend/src/pages/Category/Category.spec.tsx
@@ -33,6 +33,7 @@ function product(index: number): Product {
     name: `Product ${index}`,
     description: "Catalog product",
     imgUrls: [`product-${index}.jpg`],
+    categoryIds: ["category-id"],
     currentPrice: 1000 + index,
     oldPrice: 1200 + index,
   };

--- a/frontend/src/pages/Home/Home.spec.tsx
+++ b/frontend/src/pages/Home/Home.spec.tsx
@@ -22,6 +22,7 @@ const products: Product[] = Array.from({ length: 8 }, (_, index) => ({
   slug: `product-${index}`,
   name: `Product ${index}`,
   imgUrls: [],
+  categoryIds: [],
   currentPrice: 1000 + index,
   oldPrice: 1000 + index,
 }));

--- a/frontend/src/pages/Product/Product.scss
+++ b/frontend/src/pages/Product/Product.scss
@@ -1,181 +1,94 @@
+@use "../../assets/styles/tokens" as *;
+
 .product-page {
-  font-family: "Roboto", sans-serif;
-  font-style: normal;
-  padding: 1rem;
-
-  @media (min-width: 768px) {
-    padding: 5rem;
-  }
-
-  .product-container {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 1.5rem;
-
-    @media (min-width: 768px) {
-      flex-direction: row;
-      align-items: flex-start;
-      justify-content: center;
-    }
-  }
-
-  .product-page__slider {
-    width: 100%;
-    max-width: 400px;
-
-    .swiper {
-      width: 100%;
-      height: auto;
-    }
-
-    img {
-      width: 100%;
-      height: auto;
-      border-radius: 8px;
-      object-fit: contain;
-    }
-  }
-
-  .product-details {
-    text-align: center;
-    padding: 1rem;
-    max-width: 420px;
-    margin: 0 auto;
-
-    h1 {
-      font-size: 2.5rem;
-      font-weight: 600;
-      margin-bottom: 0.75rem;
-      text-transform: capitalize;
-    }
-
-    p {
-      font-size: 1.8rem;
-      color: #444;
-      line-height: 1.4;
-      margin-bottom: 1rem;
-    }
-
-    .price {
-      display: flex;
-      justify-content: center;
-      margin: 30px 0 50px;
-
-      .current-price,
-      .old-price {
-        margin-right: 20px;
-        font-size: 24px;
-        font-weight: 700;
-      }
-
-      .current-price {
-        color: #000;
-      }
-
-      .old-price {
-        color: rgba(0, 0, 0, 0.4);
-        text-decoration-line: line-through;
-      }
-
-      .discount-badge {
-        display: flex;
-        width: 58px;
-        padding: 6px 14px;
-        justify-content: center;
-        align-items: center;
-        gap: 12px;
-        border-radius: 62px;
-        background: rgba(255, 51, 51, 0.1);
-        color: #f33;
-        font-size: 12px;
-        font-weight: 500;
-      }
-    }
-
-    .add-to-cart {
-      display: flex;
-      justify-content: center;
-      margin-top: 1rem;
-      gap: 0.5rem;
-      button {
-        max-width: 150px;
-        padding: 0.75rem;
-        border-radius: 25px;
-      }
-    }
-
-    @media (min-width: 768px) {
-      text-align: left;
-      padding: 2rem;
-
-      h1 {
-        font-size: 3rem;
-      }
-
-      p {
-        font-size: 2rem;
-      }
-
-      .price {
-        justify-content: flex-start;
-      }
-    }
-  }
+  padding-bottom: var(--space-20);
 }
 
-.modal-overlay {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.75);
-  z-index: 1000;
+.product-page .breadcrumbs {
+  margin-top: var(--space-6);
+}
+
+.product-page__main {
+  min-width: 0;
+}
+
+.product-page__hero {
+  display: grid;
+  margin-top: var(--space-8);
+  align-items: start;
+  grid-template-columns: minmax(0, 61rem) minmax(34rem, 1fr);
+  gap: var(--space-10);
+}
+
+.product-page__status {
   display: flex;
-  justify-content: center;
+  min-height: 48rem;
   align-items: center;
-}
-
-.modal-content {
-  position: relative;
-  background: #fff;
-  border-radius: 10px;
-  max-width: 90vw;
-  max-height: 90vh;
-  padding: 1rem;
-  display: flex;
+  justify-content: center;
   flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  overflow: hidden;
+  gap: var(--space-4);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-md);
+  text-align: center;
+}
 
-  .swiper-wrapper {
-    align-items: center;
+.product-page__spinner {
+  width: 3.2rem;
+  height: 3.2rem;
+  border: 0.3rem solid var(--color-border);
+  border-top-color: var(--color-ink);
+  border-radius: 50%;
+  animation: product-page-spin 700ms linear infinite;
+}
+
+.product-page__retry {
+  min-width: 14rem;
+  min-height: 4.4rem;
+  padding: var(--space-3) var(--space-5);
+  border: 0;
+  border-radius: var(--radius-pill);
+  background: var(--color-ink);
+  color: var(--color-surface);
+  cursor: pointer;
+  font: inherit;
+  font-weight: var(--font-weight-medium);
+}
+
+@keyframes product-page-spin {
+  to {
+    transform: rotate(360deg);
   }
 }
 
-.modal-close {
-  position: absolute;
-  top: 12px;
-  right: 16px;
-  font-size: 1.5rem;
-  background: none;
-  border: none;
-  color: #000;
-  cursor: pointer;
-  z-index: 2;
+@media (max-width: 1000px) {
+  .product-page__hero {
+    grid-template-columns: minmax(0, 1.1fr) minmax(30rem, 0.9fr);
+    gap: var(--space-6);
+  }
 }
 
-.modal-slider {
-  width: 100%;
-  height: 100%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
+@media (max-width: 760px) {
+  .product-page {
+    padding-bottom: var(--space-16);
+  }
+
+  .product-page .breadcrumbs {
+    margin-top: var(--space-5);
+  }
+
+  .product-page__hero {
+    margin-top: var(--space-5);
+    grid-template-columns: minmax(0, 1fr);
+    gap: var(--space-5);
+  }
+
+  .product-page__status {
+    min-height: 36rem;
+  }
 }
 
-.modal-image {
-  max-width: 100%;
-  max-height: 80vh;
-  object-fit: contain;
-  margin: auto;
-  display: block;
+@media (prefers-reduced-motion: reduce) {
+  .product-page__spinner {
+    animation-duration: 1400ms;
+  }
 }

--- a/frontend/src/pages/Product/Product.spec.tsx
+++ b/frontend/src/pages/Product/Product.spec.tsx
@@ -1,0 +1,91 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { fetchCategoryTrail } from "../../services/categoryService/categoryService";
+import { fetchProductById, fetchProductPage } from "../../services/productService/productService";
+import type { Product } from "../../services/productService/types";
+import ProductPage from "./Product";
+
+vi.mock("../../services/categoryService/categoryService", () => ({ fetchCategoryTrail: vi.fn() }));
+vi.mock("../../services/productService/productService", () => ({
+  fetchProductById: vi.fn(),
+  fetchProductPage: vi.fn(),
+}));
+vi.mock("../../components/Product/ProductGallery/ProductGallery", () => ({
+  ProductGallery: ({ productName }: { productName: string }) => <div>{productName} gallery</div>,
+}));
+vi.mock("../../components/Product/ProductPurchasePanel/ProductPurchasePanel", () => ({
+  ProductPurchasePanel: ({ product }: { product: Product }) => <h1>{product.name}</h1>,
+}));
+vi.mock("../../components/Product/RelatedProducts/RelatedProducts", () => ({
+  RelatedProducts: ({ products }: { products: Product[] }) => <div>{products.length} recommendations</div>,
+}));
+
+const product: Product = {
+  id: "product-id",
+  slug: "match-football",
+  name: "Match Football",
+  description: "Competition-ready football.",
+  imgUrls: ["football.jpg"],
+  categoryIds: ["football-id"],
+  currentPrice: 3499,
+  oldPrice: 4499,
+};
+
+function renderProduct() {
+  render(
+    <MemoryRouter initialEntries={["/product/product-id"]}>
+      <Routes>
+        <Route element={<ProductPage />} path="/product/:id" />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe("ProductPage", () => {
+  beforeEach(() => {
+    vi.mocked(fetchProductById).mockReset();
+    vi.mocked(fetchCategoryTrail).mockReset();
+    vi.mocked(fetchProductPage).mockReset();
+    vi.mocked(fetchCategoryTrail).mockResolvedValue([
+      { id: "balls-id", name: "Balls", slug: "balls", parentId: null },
+      { id: "football-id", name: "Football", slug: "football", parentId: "balls-id" },
+    ]);
+    vi.mocked(fetchProductPage).mockResolvedValue({ items: [product], offset: 0, limit: 5, total: 1 });
+  });
+
+  it("loads the product, category breadcrumbs, and related category products", async () => {
+    vi.mocked(fetchProductById).mockResolvedValue(product);
+    renderProduct();
+
+    expect(screen.getByRole("status")).toHaveTextContent("Loading product");
+    expect(await screen.findByRole("heading", { name: "Match Football" })).toBeVisible();
+
+    await waitFor(() => expect(fetchCategoryTrail).toHaveBeenCalledWith("football-id"));
+    expect(fetchProductPage).toHaveBeenCalledWith({ categoryId: "balls-id", limit: 5 });
+    expect(await screen.findByText("1 recommendations")).toBeVisible();
+    expect(screen.getByRole("navigation", { name: "Breadcrumb" })).toHaveTextContent(
+      "HomeCatalogBallsFootballMatch Football"
+    );
+  });
+
+  it("shows the not-found page for an unknown product", async () => {
+    vi.mocked(fetchProductById).mockResolvedValue(null);
+    renderProduct();
+
+    expect(await screen.findByRole("heading", { name: "404" })).toBeVisible();
+    expect(fetchCategoryTrail).not.toHaveBeenCalled();
+  });
+
+  it("lets the user retry a temporary product failure", async () => {
+    vi.mocked(fetchProductById).mockRejectedValueOnce(new Error("Network unavailable")).mockResolvedValueOnce(product);
+    renderProduct();
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Network unavailable");
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+
+    expect(await screen.findByRole("heading", { name: "Match Football" })).toBeVisible();
+    expect(fetchProductById).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/pages/Product/Product.tsx
+++ b/frontend/src/pages/Product/Product.tsx
@@ -1,153 +1,130 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useParams } from "react-router-dom";
-import { fetchProductById } from "../../services/productService/productService";
+
+import Breadcrumbs, { type Crumb } from "../../components/Breadcrumbs/Breadcrumbs";
+import { PageContainer } from "../../components/common/PageContainer/PageContainer";
+import { ProductGallery } from "../../components/Product/ProductGallery/ProductGallery";
+import { ProductPurchasePanel } from "../../components/Product/ProductPurchasePanel/ProductPurchasePanel";
+import { RelatedProducts } from "../../components/Product/RelatedProducts/RelatedProducts";
+import { fetchCategoryTrail } from "../../services/categoryService/categoryService";
+import type { Category } from "../../services/categoryService/types";
+import { fetchProductById, fetchProductPage } from "../../services/productService/productService";
 import type { Product } from "../../services/productService/types";
-import Button from "../../components/common/button/button";
+import NotFoundPage from "../NotFound/NotFound";
+
 import "./Product.scss";
-import { Swiper, SwiperSlide } from "swiper/react";
-import { Navigation, Pagination } from "swiper/modules";
-import "swiper/css";
-import "swiper/css/navigation";
-import "swiper/css/pagination";
-import { useCart } from "../../components/context/useCart";
-import Message from "../../components/common/message/Message";
+
+function categoryCrumbs(categories: Category[]): Crumb[] {
+  const segments: string[] = [];
+  return categories.map((category) => {
+    segments.push(category.slug);
+    return { name: category.name, path: `/catalog/${segments.join("/")}` };
+  });
+}
 
 export default function ProductPage() {
-  const [product, setProduct] = useState<Product | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [isModalOpen, setIsModalOpen] = useState(false);
-  const [activeImageIndex, setActiveImageIndex] = useState(0);
   const { id } = useParams<{ id: string }>();
-  const [productInCart, setProductInCart] = useState(false);
-  const [showMessage, setShowMessage] = useState(false);
-  const { cart, addToCart, removeFromCart } = useCart();
+  const [product, setProduct] = useState<Product | null>(null);
+  const [categoryTrail, setCategoryTrail] = useState<Category[]>([]);
+  const [recommendations, setRecommendations] = useState<Product[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [notFound, setNotFound] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
 
   useEffect(() => {
-    fetchProductById(id!)
-      .then((data) => {
-        if (data) setProduct(data);
-        else setError("Product not found.");
-      })
-      .catch((err) => setError(err.message));
-  }, [id]);
+    let cancelled = false;
 
-  useEffect(() => {
-    if (cart && id) {
-      setProductInCart(cart.items.some((item) => item.productId === id));
-    }
-  }, [cart, id]);
+    const loadProduct = async () => {
+      setProduct(null);
+      setCategoryTrail([]);
+      setRecommendations([]);
+      setIsLoading(true);
+      setNotFound(false);
+      setError(null);
 
-  if (error) return <div>{error}</div>;
-  if (!product) return <div>Loading product...</div>;
+      if (!id) {
+        setNotFound(true);
+        setIsLoading(false);
+        return;
+      }
 
-  const hasDiscount = product.oldPrice > product.currentPrice;
-  const discountPercentage = hasDiscount
-    ? Math.round(((product.oldPrice - product.currentPrice) / product.oldPrice) * 100)
-    : 0;
+      let nextProduct: Product | null;
+      try {
+        nextProduct = await fetchProductById(id);
+      } catch (loadError) {
+        if (!cancelled) {
+          setError(loadError instanceof Error ? loadError.message : "Unable to load this product.");
+          setIsLoading(false);
+        }
+        return;
+      }
+
+      if (cancelled) return;
+      if (!nextProduct) {
+        setNotFound(true);
+        setIsLoading(false);
+        return;
+      }
+
+      setProduct(nextProduct);
+      setIsLoading(false);
+
+      const categoryId = nextProduct.categoryIds[0];
+      if (!categoryId) return;
+
+      try {
+        const nextTrail = await fetchCategoryTrail(categoryId);
+        const recommendationCategoryId = nextTrail[0]?.id ?? categoryId;
+        const relatedPage = await fetchProductPage({ categoryId: recommendationCategoryId, limit: 5 });
+        if (!cancelled) {
+          setCategoryTrail(nextTrail);
+          setRecommendations(relatedPage.items);
+        }
+      } catch {
+        // Product context is supplementary; the product remains usable if it is unavailable.
+      }
+    };
+
+    void loadProduct();
+    return () => {
+      cancelled = true;
+    };
+  }, [id, reloadKey]);
+
+  const breadcrumbs = useMemo<Crumb[]>(() => {
+    if (!product) return [];
+    return [...categoryCrumbs(categoryTrail), { name: product.name, path: `/product/${product.id}` }];
+  }, [categoryTrail, product]);
+
+  if (notFound) return <NotFoundPage />;
 
   return (
-    <div className="product-page">
-      <div className="product-container">
-        <div className="product-page__slider">
-          {product.imgUrls.length > 1 ? (
-            <Swiper
-              modules={[Navigation, Pagination]}
-              spaceBetween={10}
-              slidesPerView={1}
-              navigation
-              pagination={{ clickable: true }}
-              loop={true}
-            >
-              {product.imgUrls.map((url, index) => (
-                <SwiperSlide key={index}>
-                  <img
-                    src={url}
-                    alt={`${product.name} ${index + 1}`}
-                    className="slider-image"
-                    onClick={() => {
-                      setActiveImageIndex(index);
-                      setIsModalOpen(true);
-                    }}
-                  />
-                </SwiperSlide>
-              ))}
-            </Swiper>
-          ) : (
-            <img
-              src={product.imgUrls[0]}
-              alt={product.name}
-              onClick={() => {
-                setActiveImageIndex(0);
-                setIsModalOpen(true);
-              }}
-            />
-          )}
+    <PageContainer className="product-page">
+      {isLoading ? (
+        <div aria-live="polite" className="product-page__status" role="status">
+          <span className="product-page__spinner" />
+          Loading product…
         </div>
-
-        <div className="product-details">
-          <h1>{product.name}</h1>
-          <p>{product.description ?? "No description available."}</p>
-          <div className="price">
-            <span className="current-price">{(product.currentPrice / 100).toFixed(2)}€</span>
-            {hasDiscount && (
-              <>
-                <span className="old-price">{(product.oldPrice / 100).toFixed(2)}€</span>
-                <span className="discount-badge">-{discountPercentage}%</span>
-              </>
-            )}
-          </div>
-          <div className="add-to-cart">
-            <Button
-              disabled={productInCart}
-              text="Add to Cart"
-              onClick={() => {
-                if (id) {
-                  addToCart(id);
-                }
-                return cart;
-              }}
-            />
-            <Button
-              disabled={!productInCart}
-              text="Remove"
-              onClick={() => {
-                if (id) {
-                  removeFromCart(id);
-                  setShowMessage(true);
-                }
-                return cart;
-              }}
-            />
-          </div>
+      ) : error ? (
+        <div className="product-page__status" role="alert">
+          <p>We couldn't load this product. {error}</p>
+          <button className="product-page__retry" onClick={() => setReloadKey((key) => key + 1)} type="button">
+            Try again
+          </button>
         </div>
-        {showMessage && (
-          <Message text="Product has been removed from the cart." onClose={() => setShowMessage(false)} />
-        )}
-      </div>
-
-      {isModalOpen && (
-        <div className="modal-overlay" onClick={() => setIsModalOpen(false)}>
-          <div className="modal-content" onClick={(e) => e.stopPropagation()}>
-            <button className="modal-close" onClick={() => setIsModalOpen(false)}>
-              ✕
-            </button>
-            <Swiper
-              modules={[Navigation, Pagination]}
-              navigation
-              pagination={{ clickable: true }}
-              initialSlide={activeImageIndex}
-              loop={true}
-              className="modal-slider"
-            >
-              {product.imgUrls.map((url, index) => (
-                <SwiperSlide key={index}>
-                  <img src={url} alt={`Enlarged ${index + 1}`} className="modal-image" />
-                </SwiperSlide>
-              ))}
-            </Swiper>
-          </div>
-        </div>
-      )}
-    </div>
+      ) : product ? (
+        <>
+          <Breadcrumbs crumbs={breadcrumbs} />
+          <main className="product-page__main">
+            <div className="product-page__hero">
+              <ProductGallery images={product.imgUrls} productName={product.name} />
+              <ProductPurchasePanel product={product} />
+            </div>
+            <RelatedProducts currentProductId={product.id} products={recommendations} />
+          </main>
+        </>
+      ) : null}
+    </PageContainer>
   );
 }

--- a/frontend/src/services/categoryService/categoryService.spec.ts
+++ b/frontend/src/services/categoryService/categoryService.spec.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { apiClient } from "../apiClient";
+import { fetchCategoryTrail } from "./categoryService";
+
+vi.mock("../apiClient", () => ({
+  apiClient: { get: vi.fn() },
+}));
+
+describe("categoryService", () => {
+  beforeEach(() => {
+    vi.mocked(apiClient.get).mockResolvedValue({
+      data: [
+        {
+          id: "balls-id",
+          name: "Balls",
+          slug: "balls",
+          parentId: null,
+          children: [
+            {
+              id: "football-id",
+              name: "Football",
+              slug: "football",
+              parentId: "balls-id",
+              children: [],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("builds an ordered category trail from the cached tree", async () => {
+    await expect(fetchCategoryTrail("football-id")).resolves.toEqual([
+      expect.objectContaining({ id: "balls-id", name: "Balls" }),
+      expect.objectContaining({ id: "football-id", name: "Football" }),
+    ]);
+    await expect(fetchCategoryTrail("unknown-id")).resolves.toEqual([]);
+    expect(apiClient.get).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/services/categoryService/categoryService.tsx
+++ b/frontend/src/services/categoryService/categoryService.tsx
@@ -20,3 +20,19 @@ export async function fetchCategoryBySlug(slug: string, parentId?: string | null
 export async function fetchChildCategories(parentId: string | null): Promise<Category[]> {
   return flatten(await categories()).filter((category) => category.parentId === parentId);
 }
+
+export async function fetchCategoryTrail(categoryId: string): Promise<Category[]> {
+  const allCategories = flatten(await categories());
+  const categoriesById = new Map(allCategories.map((category) => [category.id, category]));
+  const trail: Category[] = [];
+  const visited = new Set<string>();
+  let current = categoriesById.get(categoryId);
+
+  while (current && !visited.has(current.id)) {
+    trail.unshift(current);
+    visited.add(current.id);
+    current = current.parentId ? categoriesById.get(current.parentId) : undefined;
+  }
+
+  return trail;
+}

--- a/frontend/src/services/productService/productService.spec.ts
+++ b/frontend/src/services/productService/productService.spec.ts
@@ -1,7 +1,8 @@
+import { AxiosError } from "axios";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { apiClient } from "../apiClient";
-import { fetchProductPage, fetchProducts } from "./productService";
+import { fetchProductById, fetchProductPage, fetchProducts } from "./productService";
 
 vi.mock("../apiClient", () => ({
   apiClient: { get: vi.fn() },
@@ -55,6 +56,7 @@ describe("productService", () => {
             images: [{ url: "football.jpg", alt: "Match Football" }],
             price: { amount: 3499, currency: "EUR" },
             compareAtPrice: { amount: 4499, currency: "EUR" },
+            categoryIds: ["football-id"],
           },
         ],
         offset: 6,
@@ -71,6 +73,7 @@ describe("productService", () => {
           name: "Match Football",
           description: "",
           imgUrls: ["football.jpg"],
+          categoryIds: ["football-id"],
           currentPrice: 3499,
           oldPrice: 4499,
         },
@@ -79,5 +82,45 @@ describe("productService", () => {
       limit: 6,
       total: 8,
     });
+  });
+
+  it("maps a product detail response including its categories", async () => {
+    vi.mocked(apiClient.get).mockResolvedValueOnce({
+      data: {
+        id: "product-id",
+        slug: "match-football",
+        name: "Match Football",
+        description: "Competition-ready football.",
+        images: [{ url: "football.jpg", alt: "Match Football" }],
+        price: { amount: 3499, currency: "EUR" },
+        compareAtPrice: null,
+        categoryIds: ["football-id"],
+      },
+    });
+
+    await expect(fetchProductById("product-id")).resolves.toEqual({
+      id: "product-id",
+      slug: "match-football",
+      name: "Match Football",
+      description: "Competition-ready football.",
+      imgUrls: ["football.jpg"],
+      categoryIds: ["football-id"],
+      currentPrice: 3499,
+      oldPrice: 3499,
+    });
+  });
+
+  it("returns null only when the product does not exist", async () => {
+    vi.mocked(apiClient.get).mockRejectedValueOnce(
+      new AxiosError("Not found", "ERR_BAD_REQUEST", undefined, undefined, { status: 404 } as never)
+    );
+
+    await expect(fetchProductById("missing-id")).resolves.toBeNull();
+  });
+
+  it("preserves unexpected API failures for the page to handle", async () => {
+    vi.mocked(apiClient.get).mockRejectedValueOnce(new Error("Network unavailable"));
+
+    await expect(fetchProductById("product-id")).rejects.toThrow("Network unavailable");
   });
 });

--- a/frontend/src/services/productService/productService.ts
+++ b/frontend/src/services/productService/productService.ts
@@ -1,3 +1,5 @@
+import { isAxiosError } from "axios";
+
 import { apiClient } from "../apiClient";
 import type { Product, ProductPage } from "./types";
 
@@ -9,6 +11,7 @@ interface ProductDto {
   images: { url: string; alt: string }[];
   price: { amount: number; currency: "EUR" };
   compareAtPrice: { amount: number; currency: "EUR" } | null;
+  categoryIds: string[];
 }
 
 interface ProductPageDto {
@@ -40,6 +43,7 @@ function mapProduct(item: ProductDto): Product {
     slug: item.slug,
     description: item.description ?? "",
     imgUrls: item.images.map((image) => image.url),
+    categoryIds: item.categoryIds,
     currentPrice: item.price.amount,
     oldPrice: item.compareAtPrice?.amount ?? item.price.amount,
   };
@@ -48,8 +52,9 @@ function mapProduct(item: ProductDto): Product {
 export async function fetchProductById(productId: string): Promise<Product | null> {
   try {
     return mapProduct((await apiClient.get<ProductDto>(`/catalog/products/${productId}`)).data);
-  } catch {
-    return null;
+  } catch (error) {
+    if (isAxiosError(error) && error.response?.status === 404) return null;
+    throw error;
   }
 }
 

--- a/frontend/src/services/productService/types.ts
+++ b/frontend/src/services/productService/types.ts
@@ -4,8 +4,9 @@ export interface Product {
   slug: string;
   description?: string;
   imgUrls: string[];
-  currentPrice: number; //in centes
-  oldPrice: number; //in centes
+  categoryIds: string[];
+  currentPrice: number; // in cents
+  oldPrice: number; // in cents
 }
 
 export interface ProductPage {


### PR DESCRIPTION
## Summary

Redesigns the product details experience around the saved desktop and mobile Figma references while keeping every interactive control backed by the real NestJS API.

## What changed

### Product data flow
- preserves product category metadata returned by the catalog API
- distinguishes a real product 404 from temporary API failures
- resolves an ordered category trail from the cached category tree
- loads recommendations from the product's root category without blocking the primary product view

### Product experience
- adds an accessible responsive product gallery with thumbnails and an enlarged-image dialog
- handles single-image and missing-image products without placeholder controls
- adds server-backed quantity selection from 1 to 99
- sends the selected quantity through CartContext to the existing cart API
- adds real EUR pricing, compare-at pricing, discount percentage, and product descriptions
- adds success and retryable error feedback for cart operations
- adds responsive related-product recommendations

### Page states and accessibility
- adds loading, retry, and product-not-found states
- builds semantic breadcrumbs from the actual category hierarchy
- supports keyboard focus, Escape-to-close, body scroll locking, and ARIA labels
- matches the two-column desktop and single-column mobile layouts without horizontal overflow
- intentionally omits sizes, colors, ratings, and reviews because those domains are not present in the backend contract

### Maintenance
- removes the old Swiper-based page implementation
- reduces the production JavaScript bundle from roughly 500 KB to 411 KB
- adds focused unit/component coverage and a real Playwright quantity-purchase scenario

## Validation

- `npm run format:check`
- `npm run lint`
- `npm run prisma:validate --workspace backend`
- frontend: 42 test files, 76 tests passed
- backend: 7 test files, 17 tests passed
- frontend and backend production builds passed
- backend API e2e passed
- Playwright: 2 smoke scenarios passed
- desktop QA at 1280 px: 610 px gallery, two-column layout, no horizontal overflow
- mobile QA at 390 px: single-column layout, 343 px content width, no horizontal overflow
- verified quantity 3 reaches the backend and updates the header cart badge
- verified enlarged gallery closes with Escape and restores scrolling
