### PR TITLE
feat(auth): redesign multi-step registration experience

### DIFF
--- a/backend/src/users/dto/change-password.dto.spec.ts
+++ b/backend/src/users/dto/change-password.dto.spec.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+
+import { STRONG_PASSWORD } from "./change-password.dto.js";
+
+describe("STRONG_PASSWORD", () => {
+  it("accepts an underscore as the required special character", () => {
+    expect(STRONG_PASSWORD.test("Strong_Pass1")).toBe(true);
+  });
+
+  it("rejects characters outside the supported password alphabet", () => {
+    expect(STRONG_PASSWORD.test("Strong/Pass1!")).toBe(false);
+  });
+});

--- a/backend/src/users/dto/change-password.dto.ts
+++ b/backend/src/users/dto/change-password.dto.ts
@@ -1,6 +1,7 @@
 import { IsString, Matches, MinLength } from "class-validator";
 
-export const STRONG_PASSWORD = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).{8,128}$/;
+export const STRONG_PASSWORD =
+  /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*(),.?":{}|<>_])[A-Za-z0-9!@#$%^&*(),.?":{}|<>_]{8,128}$/;
 
 export class ChangePasswordDto {
   @IsString()

--- a/e2e/store.spec.ts
+++ b/e2e/store.spec.ts
@@ -7,15 +7,19 @@ test("registers, shops with a promo code, opens profile and logs out", async ({ 
   await page.getByPlaceholder("John").fill("Playwright");
   await page.getByPlaceholder("Doe").fill("User");
   await page.getByPlaceholder("you@example.com").fill(email);
-  await page.getByPlaceholder("Enter your password", { exact: true }).fill("Strong!Pass1");
-  await page.getByPlaceholder("Re-enter your password").fill("Strong!Pass1");
-  await page.locator('input[type="date"]').fill("1990-01-01");
-  await page.getByPlaceholder("Enter street address").fill("Browser Street 1");
-  await page.getByPlaceholder("Brussels").fill("Berlin");
-  await page.getByPlaceholder(/Enter postal code/).fill("10115");
-  await page.locator("select").selectOption("DE");
-  await page.locator('input[type="checkbox"]').check();
-  await page.locator(".register-btn").click();
+  await page.getByPlaceholder("Create a password").fill("Strong!Pass1");
+  await page.getByPlaceholder("Repeat your password").fill("Strong!Pass1");
+  await page.getByRole("button", { name: "Continue" }).click();
+
+  await page.getByLabel("Date of birth").fill("1990-01-01");
+  await page.getByRole("button", { name: "Continue" }).click();
+
+  await page.getByLabel("Street address").fill("Browser Street 1");
+  await page.getByLabel("City").fill("Berlin");
+  await page.getByLabel("Postal code").fill("10115");
+  await page.getByLabel("Country").selectOption("DE");
+  await page.getByRole("checkbox", { name: "Use as default billing and shipping address" }).check();
+  await page.getByRole("button", { name: "Create account" }).click();
 
   await expect(page.getByRole("link", { name: "Open profile" })).toBeVisible();
   await page.getByRole("link", { name: "Catalog" }).click();

--- a/frontend/src/components/Auth/AuthFormField/AuthFormField.scss
+++ b/frontend/src/components/Auth/AuthFormField/AuthFormField.scss
@@ -11,7 +11,7 @@
 }
 
 .auth-form-field__error {
-  min-height: 1.7rem;
+  min-height: 3.4rem;
   color: var(--color-danger);
   font-size: var(--font-size-xs);
   line-height: var(--line-height-body);

--- a/frontend/src/components/Auth/AuthFormField/AuthFormField.scss
+++ b/frontend/src/components/Auth/AuthFormField/AuthFormField.scss
@@ -1,0 +1,18 @@
+.auth-form-field {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.auth-form-field label {
+  color: var(--color-ink);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  line-height: var(--line-height-body);
+}
+
+.auth-form-field__error {
+  min-height: 1.7rem;
+  color: var(--color-danger);
+  font-size: var(--font-size-xs);
+  line-height: var(--line-height-body);
+}

--- a/frontend/src/components/Auth/AuthFormField/AuthFormField.spec.tsx
+++ b/frontend/src/components/Auth/AuthFormField/AuthFormField.spec.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { AuthFormField } from "./AuthFormField";
+
+describe("AuthFormField", () => {
+  it("associates its label and stable error region with a control", () => {
+    const { rerender } = render(
+      <AuthFormField inputId="email" label="Email address">
+        <input id="email" />
+      </AuthFormField>
+    );
+
+    expect(screen.getByLabelText("Email address")).toHaveAttribute("id", "email");
+    expect(document.querySelector("#email-error")).toBeEmptyDOMElement();
+
+    rerender(
+      <AuthFormField error="Enter a valid email." inputId="email" label="Email address">
+        <input id="email" />
+      </AuthFormField>
+    );
+
+    expect(document.querySelector("#email-error")).toHaveTextContent("Enter a valid email.");
+  });
+});

--- a/frontend/src/components/Auth/AuthFormField/AuthFormField.tsx
+++ b/frontend/src/components/Auth/AuthFormField/AuthFormField.tsx
@@ -1,0 +1,22 @@
+import type { ReactNode } from "react";
+
+import "./AuthFormField.scss";
+
+type AuthFormFieldProps = {
+  children: ReactNode;
+  error?: string;
+  inputId: string;
+  label: string;
+};
+
+export function AuthFormField({ children, error = "", inputId, label }: AuthFormFieldProps) {
+  return (
+    <div className="auth-form-field">
+      <label htmlFor={inputId}>{label}</label>
+      {children}
+      <p aria-live="polite" className="auth-form-field__error" id={`${inputId}-error`}>
+        {error}
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/components/Auth/RegistrationProgress/RegistrationProgress.scss
+++ b/frontend/src/components/Auth/RegistrationProgress/RegistrationProgress.scss
@@ -1,0 +1,67 @@
+.registration-progress ol {
+  display: grid;
+  padding: 0;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  list-style: none;
+}
+
+.registration-progress li {
+  position: relative;
+  display: grid;
+  justify-items: center;
+  gap: var(--space-2);
+  color: var(--color-text-subtle);
+  font-size: var(--font-size-xs);
+  text-align: center;
+}
+
+.registration-progress li:not(:last-child)::after {
+  position: absolute;
+  z-index: 0;
+  top: 1.5rem;
+  right: calc(-50% + 2.2rem);
+  left: calc(50% + 2.2rem);
+  height: 1px;
+  background: var(--color-border);
+  content: "";
+}
+
+.registration-progress__number {
+  position: relative;
+  z-index: 1;
+  display: inline-flex;
+  width: 3.2rem;
+  height: 3.2rem;
+  align-items: center;
+  justify-content: center;
+  border: var(--border-subtle);
+  border-radius: 50%;
+  background: var(--color-surface);
+  font-weight: var(--font-weight-medium);
+}
+
+.registration-progress__current,
+.registration-progress__completed {
+  color: var(--color-ink);
+}
+
+.registration-progress__current .registration-progress__number,
+.registration-progress__completed .registration-progress__number {
+  border-color: var(--color-ink);
+  background: var(--color-ink);
+  color: var(--color-surface);
+}
+
+.registration-progress__current .registration-progress__label {
+  font-weight: var(--font-weight-medium);
+}
+
+@media (max-width: 480px) {
+  .registration-progress li {
+    gap: var(--space-1);
+  }
+
+  .registration-progress__label {
+    font-size: 1.1rem;
+  }
+}

--- a/frontend/src/components/Auth/RegistrationProgress/RegistrationProgress.spec.tsx
+++ b/frontend/src/components/Auth/RegistrationProgress/RegistrationProgress.spec.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { RegistrationProgress } from "./RegistrationProgress";
+
+describe("RegistrationProgress", () => {
+  it("marks previous, current and upcoming steps", () => {
+    render(<RegistrationProgress currentStep={1} />);
+
+    const progress = screen.getByRole("navigation", { name: "Registration progress" });
+    const steps = screen.getAllByRole("listitem");
+
+    expect(progress).toBeVisible();
+    expect(steps[0]).toHaveClass("registration-progress__completed");
+    expect(steps[1]).toHaveClass("registration-progress__current");
+    expect(steps[1]).toHaveAttribute("aria-current", "step");
+    expect(steps[2]).toHaveClass("registration-progress__upcoming");
+  });
+});

--- a/frontend/src/components/Auth/RegistrationProgress/RegistrationProgress.tsx
+++ b/frontend/src/components/Auth/RegistrationProgress/RegistrationProgress.tsx
@@ -1,0 +1,32 @@
+import "./RegistrationProgress.scss";
+
+const REGISTRATION_STEPS = ["Account", "Personal details", "Address"] as const;
+
+type RegistrationProgressProps = {
+  currentStep: number;
+};
+
+export function RegistrationProgress({ currentStep }: RegistrationProgressProps) {
+  return (
+    <nav aria-label="Registration progress" className="registration-progress">
+      <ol>
+        {REGISTRATION_STEPS.map((step, index) => {
+          const state = index < currentStep ? "completed" : index === currentStep ? "current" : "upcoming";
+
+          return (
+            <li
+              aria-current={state === "current" ? "step" : undefined}
+              className={`registration-progress__${state}`}
+              key={step}
+            >
+              <span aria-hidden="true" className="registration-progress__number">
+                {index + 1}
+              </span>
+              <span className="registration-progress__label">{step}</span>
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}

--- a/frontend/src/pages/Registration/Registration.scss
+++ b/frontend/src/pages/Registration/Registration.scss
@@ -139,7 +139,7 @@
 }
 
 .registration-form__server-error {
-  min-height: 5.8rem;
+  min-height: 6.4rem;
   margin-top: var(--space-4);
 }
 

--- a/frontend/src/pages/Registration/Registration.scss
+++ b/frontend/src/pages/Registration/Registration.scss
@@ -1,56 +1,216 @@
-.registration-wrapper {
-  max-width: 500px;
-  padding: 30px;
-  margin: 2rem auto;
-  background: #f0f0f0;
-  border-radius: 40px;
-
+.registration-form {
   display: flex;
+  width: 100%;
+  max-width: 52rem;
   flex-direction: column;
-  gap: 30px;
 }
 
-.field-group {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-.field-group-def-adress {
-  align-self: center;
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-
-.register-btn {
+.registration-form__header {
   text-align: center;
-  margin: 0 auto;
-  cursor: pointer;
 }
 
-.login-link {
-  font-size: 16px;
-  text-align: center;
-  margin: 0 auto;
-  cursor: pointer;
-
-  span {
-    text-decoration: underline;
-  }
+.registration-form__step-count {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
-select.input {
+.registration-form__header h1 {
+  margin-top: var(--space-2);
+  color: var(--color-ink);
+  font-family: var(--font-family-heading);
+  font-size: var(--font-size-4xl);
+  font-weight: var(--font-weight-bold);
+  letter-spacing: -0.03em;
+  line-height: var(--line-height-heading);
+}
+
+.registration-form__header h1:focus {
+  outline: none;
+}
+
+.registration-form__header > p:last-child {
+  margin-top: var(--space-3);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-md);
+  line-height: var(--line-height-relaxed);
+}
+
+.registration-form .registration-progress {
+  margin-top: var(--space-8);
+}
+
+.registration-form__step {
+  display: grid;
+  margin-top: var(--space-8);
+  gap: var(--space-4);
+}
+
+.registration-form__name-fields,
+.registration-form__address-row {
+  display: grid;
+  gap: var(--space-4);
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.registration-form .input {
+  min-height: 5.6rem;
+  border-color: var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
+}
+
+.registration-form .input:hover:not(:disabled) {
+  border-color: var(--color-text-subtle);
+}
+
+.registration-form .input:focus,
+.registration-form .input:focus-visible {
+  border-color: var(--color-ink);
+}
+
+.registration-form select.input {
   appearance: none;
   background-image: url("data:image/svg+xml;utf8,<svg fill='gray' height='16' viewBox='0 0 20 20' width='16' xmlns='http://www.w3.org/2000/svg'><path d='M5.293 7.293l4.707 4.707 4.707-4.707-1.414-1.414L10 9.586 6.707 5.879z'/></svg>");
+  background-position: right var(--space-4) center;
   background-repeat: no-repeat;
-  background-position: right 1.5rem top 55%;
   background-size: 2rem;
+  cursor: pointer;
 }
 
-.input-wrapper input[type="date"]::-webkit-calendar-picker-indicator {
+.registration-form .input-wrapper input[type="date"]::-webkit-calendar-picker-indicator {
   position: absolute;
-  right: 1.5rem;
   z-index: 1;
+  right: var(--space-4);
   cursor: pointer;
+}
+
+.registration-form__help {
+  margin-top: var(--space-1);
+  color: var(--color-text-subtle);
+  font-size: var(--font-size-xs);
+  line-height: var(--line-height-body);
+}
+
+.registration-form__step-intro {
+  margin-bottom: var(--space-2);
+}
+
+.registration-form__step-intro h2 {
+  color: var(--color-ink);
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-medium);
+  line-height: var(--line-height-heading);
+}
+
+.registration-form__step-intro p {
+  margin-top: var(--space-2);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-relaxed);
+}
+
+.registration-form__default-address {
+  display: flex;
+  min-height: 4.8rem;
+  padding: var(--space-3) var(--space-4);
+  align-items: center;
+  gap: var(--space-3);
+  border: var(--border-subtle);
+  border-radius: var(--radius-sm);
+  color: var(--color-ink);
+  cursor: pointer;
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-body);
+}
+
+.registration-form__default-address:hover {
+  border-color: var(--color-text-subtle);
+}
+
+.registration-form__default-address input {
+  width: 2rem;
+  height: 2rem;
+  flex: 0 0 auto;
+  accent-color: var(--color-ink);
+  cursor: pointer;
+}
+
+.registration-form__server-error {
+  min-height: 5.8rem;
+  margin-top: var(--space-4);
+}
+
+.registration-form__server-error p {
+  padding: var(--space-3) var(--space-4);
+  border: 1px solid rgb(255 51 51 / 32%);
+  border-radius: var(--radius-sm);
+  background: rgb(255 51 51 / 7%);
+  color: var(--color-danger);
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-body);
+  text-align: center;
+}
+
+.registration-form__actions {
+  display: grid;
+  gap: var(--space-3);
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.registration-form__actions .btn {
+  max-width: none;
+  border-radius: var(--radius-sm);
+}
+
+.registration-form__actions .btn:only-child {
+  grid-column: 1 / -1;
+}
+
+.registration-form__login-link {
+  margin-top: var(--space-5);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-body);
+  text-align: center;
+}
+
+.registration-form__login-link a {
+  color: var(--color-ink);
+  font-weight: var(--font-weight-medium);
+  text-underline-offset: 0.25em;
+}
+
+.registration-form__login-link a:hover {
+  text-decoration-thickness: 0.15em;
+}
+
+@media (max-width: 480px) {
+  .registration-form__header h1 {
+    font-size: var(--font-size-2xl);
+  }
+
+  .registration-form__header > p:last-child {
+    font-size: var(--font-size-sm);
+  }
+
+  .registration-form .registration-progress,
+  .registration-form__step {
+    margin-top: var(--space-6);
+  }
+
+  .registration-form__name-fields,
+  .registration-form__address-row {
+    grid-template-columns: 1fr;
+  }
+
+  .registration-form__actions {
+    grid-template-columns: 1fr;
+  }
+
+  .registration-form__actions .btn:only-child {
+    grid-column: auto;
+  }
 }

--- a/frontend/src/pages/Registration/Registration.spec.tsx
+++ b/frontend/src/pages/Registration/Registration.spec.tsx
@@ -1,0 +1,179 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, useLocation } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useAuth } from "../../components/context/useAuth";
+import { useCart } from "../../components/context/useCart";
+import { signUp } from "../../services/customerService/customerService";
+
+import RegistrationPage from "./Registration";
+
+vi.mock("../../components/context/useAuth", () => ({ useAuth: vi.fn() }));
+vi.mock("../../components/context/useCart", () => ({ useCart: vi.fn() }));
+vi.mock("../../services/customerService/customerService", () => ({ signUp: vi.fn() }));
+
+const signUpMock = vi.mocked(signUp);
+const refreshUser = vi.fn();
+const setNewCart = vi.fn();
+
+function CurrentPath() {
+  return <output data-testid="current-path">{useLocation().pathname}</output>;
+}
+
+function renderRegistration() {
+  return render(
+    <MemoryRouter initialEntries={["/registration"]}>
+      <RegistrationPage />
+      <CurrentPath />
+    </MemoryRouter>
+  );
+}
+
+function fillAccountStep() {
+  fireEvent.change(screen.getByRole("textbox", { name: "First name" }), { target: { value: "John" } });
+  fireEvent.change(screen.getByRole("textbox", { name: "Last name" }), { target: { value: "Doe" } });
+  fireEvent.change(screen.getByRole("textbox", { name: "Email address" }), {
+    target: { value: "john@example.com" },
+  });
+  fireEvent.change(screen.getByLabelText("Password"), { target: { value: "Password1!" } });
+  fireEvent.change(screen.getByLabelText("Confirm password"), { target: { value: "Password1!" } });
+}
+
+function continueToPersonalStep() {
+  fillAccountStep();
+  fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+}
+
+function continueToAddressStep() {
+  continueToPersonalStep();
+  fireEvent.change(screen.getByLabelText("Date of birth"), { target: { value: "1990-01-01" } });
+  fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+}
+
+function fillAddressStep() {
+  fireEvent.change(screen.getByRole("textbox", { name: "Street address" }), {
+    target: { value: "10 Main Street" },
+  });
+  fireEvent.change(screen.getByRole("textbox", { name: "City" }), { target: { value: "Berlin" } });
+  fireEvent.change(screen.getByRole("textbox", { name: "Postal code" }), { target: { value: "10115" } });
+  fireEvent.change(screen.getByRole("combobox", { name: "Country" }), { target: { value: "DE" } });
+}
+
+describe("RegistrationPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useAuth).mockReturnValue({ isAuthenticated: false, refreshUser } as never);
+    vi.mocked(useCart).mockReturnValue({ setNewCart } as never);
+    refreshUser.mockResolvedValue(null);
+  });
+
+  it("starts with an accessible account step and reserved error regions", () => {
+    renderRegistration();
+
+    expect(screen.getByRole("heading", { level: 1, name: "Create your account" })).toBeVisible();
+    expect(screen.getByRole("navigation", { name: "Registration progress" })).toBeVisible();
+    expect(screen.getByText("Step 1 of 3")).toBeVisible();
+    expect(screen.getByRole("form", { name: "Create your Sport Gear account" })).toBeVisible();
+    expect(document.querySelector("#registration-email-error")).toBeEmptyDOMElement();
+    expect(document.querySelector("#registration-password-error")).toBeEmptyDOMElement();
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+  });
+
+  it("validates only the current step and focuses its first invalid field", async () => {
+    renderRegistration();
+
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+
+    expect(screen.getByText("First name is required.")).toBeVisible();
+    expect(screen.queryByText("Date of birth is required.")).not.toBeInTheDocument();
+    await waitFor(() => expect(screen.getByRole("textbox", { name: "First name" })).toHaveFocus());
+    expect(signUpMock).not.toHaveBeenCalled();
+  });
+
+  it("controls password and confirmation visibility independently", () => {
+    renderRegistration();
+
+    const password = screen.getByLabelText("Password");
+    const confirmation = screen.getByLabelText("Confirm password");
+    const visibilityButtons = screen.getAllByRole("button", { name: "Show password" });
+
+    fireEvent.click(visibilityButtons[0]);
+    expect(password).toHaveAttribute("type", "text");
+    expect(confirmation).toHaveAttribute("type", "password");
+
+    fireEvent.click(visibilityButtons[1]);
+    expect(confirmation).toHaveAttribute("type", "text");
+  });
+
+  it("moves between steps without losing entered account data", () => {
+    renderRegistration();
+    continueToPersonalStep();
+
+    expect(screen.getByText("Step 2 of 3")).toBeVisible();
+    expect(screen.getByRole("heading", { level: 2, name: "A little about you" })).toBeVisible();
+
+    fireEvent.click(screen.getByRole("button", { name: "Back" }));
+
+    expect(screen.getByRole("textbox", { name: "Email address" })).toHaveValue("john@example.com");
+  });
+
+  it("submits all steps, restores the cart and redirects home", async () => {
+    const cart = { id: "cart-id" };
+    signUpMock.mockResolvedValue({ cart } as never);
+    renderRegistration();
+    continueToAddressStep();
+    fillAddressStep();
+    fireEvent.click(screen.getByRole("checkbox", { name: "Use as default billing and shipping address" }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Create account" }));
+
+    await waitFor(() =>
+      expect(signUpMock).toHaveBeenCalledWith(
+        "john@example.com",
+        "Password1!",
+        "John",
+        "Doe",
+        "1990-01-01",
+        [{ streetName: "10 Main Street", city: "Berlin", postalCode: "10115", country: "DE" }],
+        true
+      )
+    );
+    expect(setNewCart).toHaveBeenCalledWith(cart);
+    expect(refreshUser).toHaveBeenCalledOnce();
+    expect(screen.getByTestId("current-path")).toHaveTextContent("/");
+  });
+
+  it("disables navigation while account creation is pending", async () => {
+    let resolveRegistration: (value: Awaited<ReturnType<typeof signUp>>) => void = () => undefined;
+    signUpMock.mockReturnValue(
+      new Promise((resolve) => {
+        resolveRegistration = resolve;
+      })
+    );
+    renderRegistration();
+    continueToAddressStep();
+    fillAddressStep();
+
+    fireEvent.click(screen.getByRole("button", { name: "Create account" }));
+
+    expect(screen.getByRole("button", { name: "Creating account…" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Back" })).toBeDisabled();
+
+    await act(async () => resolveRegistration({ cart: { id: "cart-id" } } as never));
+  });
+
+  it("keeps the final step visible and shows a clear API error", async () => {
+    signUpMock.mockRejectedValue(new Error("Conflict"));
+    renderRegistration();
+    continueToAddressStep();
+    fillAddressStep();
+
+    fireEvent.click(screen.getByRole("button", { name: "Create account" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "We couldn't create your account. Please review your details and try again."
+    );
+    expect(screen.getByText("Step 3 of 3")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Create account" })).toBeEnabled();
+  });
+});

--- a/frontend/src/pages/Registration/Registration.tsx
+++ b/frontend/src/pages/Registration/Registration.tsx
@@ -1,367 +1,159 @@
-import { useState, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
-import {
-  validateEmailFormat,
-  validatePasswordStrength,
-  validateName,
-  validateDateOfBirth,
-  validateStreet,
-  validateCity,
-  validatePostalCode,
-  validateCountry,
-} from "../../utils/validation";
-import { FaLock, FaEnvelope, FaEye, FaEyeSlash, FaUser, FaCalendar, FaMapMarkerAlt } from "react-icons/fa";
+import { type FormEvent, useEffect, useRef, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+
+import { AuthLayout } from "../../components/Auth/AuthLayout/AuthLayout";
+import { RegistrationProgress } from "../../components/Auth/RegistrationProgress/RegistrationProgress";
 import Button from "../../components/common/button/button";
-import InputField from "../../components/common/inputField/inputField";
-import Paragraph from "../../components/common/paragraph/paragraph";
-import Link from "../../components/common/link/link";
-import { H2 } from "../../components/common/headings/H2";
-import { signUp } from "../../services/customerService/customerService";
-import { useCart } from "../../components/context/useCart";
 import { useAuth } from "../../components/context/useAuth";
+import { useCart } from "../../components/context/useCart";
+import { signUp } from "../../services/customerService/customerService";
+import {
+  RegistrationAccountStep,
+  RegistrationAddressStep,
+  RegistrationPersonalStep,
+  type RegistrationUpdate,
+} from "./RegistrationSteps";
+import {
+  hasRegistrationErrors,
+  INITIAL_REGISTRATION_FORM,
+  REGISTRATION_FIELD_IDS,
+  STEP_FIELDS,
+  validateRegistrationStep,
+  type RegistrationErrors,
+  type RegistrationStep,
+} from "./registrationForm";
+
 import "./Registration.scss";
 
 export default function RegistrationPage() {
   const { isAuthenticated, refreshUser } = useAuth();
-  const navigate = useNavigate();
-  useEffect(() => {
-    if (isAuthenticated) {
-      navigate("/");
-    }
-  }, [isAuthenticated, navigate]);
   const { setNewCart } = useCart();
+  const navigate = useNavigate();
+  const stepHeadingRef = useRef<HTMLHeadingElement>(null);
+  const hasChangedStep = useRef(false);
+
+  const [currentStep, setCurrentStep] = useState<RegistrationStep>(0);
+  const [data, setData] = useState(INITIAL_REGISTRATION_FORM);
+  const [errors, setErrors] = useState<RegistrationErrors>({});
   const [authError, setAuthError] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [passwordVisible, setPasswordVisible] = useState(false);
+  const [confirmPasswordVisible, setConfirmPasswordVisible] = useState(false);
 
-  const [firstName, setFirstName] = useState("");
-  const [lastName, setLastName] = useState("");
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
-  const [confirmPassword, setConfirmPassword] = useState("");
-  const [dob, setDob] = useState("");
-  const [street, setStreet] = useState("");
-  const [city, setCity] = useState("");
-  const [postalCode, setPostalCode] = useState("");
-  const [country, setCountry] = useState("");
-  const [showPassword, setShowPassword] = useState(false);
+  useEffect(() => {
+    if (isAuthenticated) navigate("/");
+  }, [isAuthenticated, navigate]);
 
-  const [emailError, setEmailError] = useState("");
-  const [passwordError, setPasswordError] = useState("");
-  const [confirmPasswordError, setConfirmPasswordError] = useState("");
-  const [firstNameError, setFirstNameError] = useState("");
-  const [lastNameError, setLastNameError] = useState("");
-  const [dobError, setDobError] = useState("");
-  const [streetError, setStreetError] = useState("");
-  const [cityError, setCityError] = useState("");
-  const [postalCodeError, setPostalCodeError] = useState("");
-  const [isDefaultAdress, setAsDefaultAdress] = useState(false);
+  useEffect(() => {
+    if (hasChangedStep.current) stepHeadingRef.current?.focus();
+    else hasChangedStep.current = true;
+  }, [currentStep]);
 
-  const countryOptions = [
-    { value: "", label: "Select a country" },
-    { value: "AT", label: "Austria" },
-    { value: "BE", label: "Belgium" },
-    { value: "BG", label: "Bulgaria" },
-    { value: "HR", label: "Croatia" },
-    { value: "CY", label: "Cyprus" },
-    { value: "CZ", label: "Czech Republic" },
-    { value: "DK", label: "Denmark" },
-    { value: "EE", label: "Estonia" },
-    { value: "FI", label: "Finland" },
-    { value: "FR", label: "France" },
-    { value: "DE", label: "Germany" },
-    { value: "GR", label: "Greece" },
-    { value: "HU", label: "Hungary" },
-    { value: "IE", label: "Ireland" },
-    { value: "IT", label: "Italy" },
-    { value: "LV", label: "Latvia" },
-    { value: "LT", label: "Lithuania" },
-    { value: "LU", label: "Luxembourg" },
-    { value: "MT", label: "Malta" },
-    { value: "NL", label: "Netherlands" },
-    { value: "PL", label: "Poland" },
-    { value: "PT", label: "Portugal" },
-    { value: "RO", label: "Romania" },
-    { value: "SK", label: "Slovakia" },
-    { value: "SI", label: "Slovenia" },
-    { value: "ES", label: "Spain" },
-    { value: "SE", label: "Sweden" },
-  ];
-
-  const [countryError, setCountryError] = useState("");
-
-  const toggleShowPassword = (e: React.MouseEvent<HTMLSpanElement>) => {
-    e.preventDefault();
-    setShowPassword((prev) => !prev);
+  const updateField: RegistrationUpdate = (field, value) => {
+    setData((currentData) => ({ ...currentData, [field]: value }));
+    setErrors((currentErrors) => ({ ...currentErrors, [field]: undefined }));
+    setAuthError("");
   };
 
-  const validateEmail = (value: string) => {
-    const error = validateEmailFormat(value);
-    setEmailError(error || "");
-    return !error;
+  const validateCurrentStep = () => {
+    const stepErrors = validateRegistrationStep(currentStep, data);
+    setErrors(stepErrors);
+
+    if (!hasRegistrationErrors(stepErrors)) return true;
+
+    const firstInvalidField = STEP_FIELDS[currentStep].find((field) => stepErrors[field]);
+    if (firstInvalidField) {
+      requestAnimationFrame(() => document.getElementById(REGISTRATION_FIELD_IDS[firstInvalidField])?.focus());
+    }
+    return false;
   };
 
-  const validatePassword = (value: string) => {
-    const error = validatePasswordStrength(value);
-    setPasswordError(error || "");
-    return !error;
+  const goBack = () => {
+    if (currentStep === 0) return;
+    setErrors({});
+    setAuthError("");
+    setCurrentStep((currentStep - 1) as RegistrationStep);
   };
 
-  const validateConfirmPassword = (value: string) => {
-    const isValid = value === password;
-    setConfirmPasswordError(isValid ? "" : "Passwords do not match.");
-    return isValid;
-  };
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!validateCurrentStep()) return;
 
-  const handleRegister = async () => {
-    const isEmailValid = validateEmail(email);
-    const isPasswordValid = validatePassword(password);
-    const isConfirmValid = validateConfirmPassword(confirmPassword);
-    const firstNameValid = !validateName(firstName, "First name");
-    setFirstNameError(validateName(firstName, "First name") || "");
-    const lastNameValid = !validateName(lastName, "Last name");
-    setLastNameError(validateName(lastName, "Last name") || "");
-    const dobValid = !validateDateOfBirth(dob);
-    setDobError(validateDateOfBirth(dob) || "");
-    const streetValid = !validateStreet(street);
-    setStreetError(validateStreet(street) || "");
-    const cityValid = !validateCity(city);
-    setCityError(validateCity(city) || "");
-    const postalValid = !validatePostalCode(postalCode);
-    setPostalCodeError(validatePostalCode(postalCode) || "");
-    const countryValid = !validateCountry(country);
-    setCountryError(validateCountry(country) || "");
+    if (currentStep < 2) {
+      setErrors({});
+      setCurrentStep((currentStep + 1) as RegistrationStep);
+      return;
+    }
 
-    if (
-      isEmailValid &&
-      isPasswordValid &&
-      isConfirmValid &&
-      firstNameValid &&
-      lastNameValid &&
-      dobValid &&
-      streetValid &&
-      cityValid &&
-      postalValid &&
-      countryValid
-    ) {
-      try {
-        setAuthError("");
-        const customer = await signUp(
-          email,
-          password,
-          firstName,
-          lastName,
-          dob,
-          [
-            {
-              streetName: street,
-              city,
-              postalCode,
-              country,
-            },
-          ],
-          isDefaultAdress
-        );
-        setNewCart(customer.cart);
-        await refreshUser();
-        setAsDefaultAdress(false);
-        navigate("/");
-      } catch {
-        setAuthError("Sign up failed. Pls try again");
-      }
+    try {
+      setAuthError("");
+      setIsSubmitting(true);
+      const customer = await signUp(
+        data.email,
+        data.password,
+        data.firstName,
+        data.lastName,
+        data.dateOfBirth,
+        [{ streetName: data.street, city: data.city, postalCode: data.postalCode, country: data.country }],
+        data.useAsDefaultAddress
+      );
+      setNewCart(customer.cart);
+      await refreshUser();
+      navigate("/");
+    } catch {
+      setAuthError("We couldn't create your account. Please review your details and try again.");
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
   return (
-    <div className="registration-wrapper">
-      <H2 text="Sign up" />
+    <AuthLayout>
+      <form
+        aria-label="Create your Sport Gear account"
+        className="registration-form"
+        noValidate
+        onSubmit={handleSubmit}
+      >
+        <header className="registration-form__header">
+          <p className="registration-form__step-count">Step {currentStep + 1} of 3</p>
+          <h1 ref={stepHeadingRef} tabIndex={-1}>
+            Create your account
+          </h1>
+          <p>Join Sport Gear in three quick steps.</p>
+        </header>
 
-      <div className="field-group">
-        <Paragraph text="First name" />
-        <InputField
-          value={firstName}
-          onChange={(v) => {
-            setFirstName(v);
-            if (firstNameError) setFirstNameError(validateName(v, "First name") || "");
-          }}
-          isValid={!firstNameError}
-          placeholder="John"
-          icon={<FaUser />}
-        />
-        {firstNameError && <Paragraph text={firstNameError} isError />}
-      </div>
+        <RegistrationProgress currentStep={currentStep} />
 
-      <div className="field-group">
-        <Paragraph text="Last name" />
-        <InputField
-          value={lastName}
-          onChange={(v) => {
-            setLastName(v);
-            if (lastNameError) setLastNameError(validateName(v, "Last name") || "");
-          }}
-          isValid={!lastNameError}
-          placeholder="Doe"
-          icon={<FaUser />}
-        />
-        {lastNameError && <Paragraph text={lastNameError} isError />}
-      </div>
+        {currentStep === 0 && (
+          <RegistrationAccountStep
+            confirmPasswordVisible={confirmPasswordVisible}
+            data={data}
+            errors={errors}
+            onChange={updateField}
+            onToggleConfirmPassword={() => setConfirmPasswordVisible((isVisible) => !isVisible)}
+            onTogglePassword={() => setPasswordVisible((isVisible) => !isVisible)}
+            passwordVisible={passwordVisible}
+          />
+        )}
+        {currentStep === 1 && <RegistrationPersonalStep data={data} errors={errors} onChange={updateField} />}
+        {currentStep === 2 && <RegistrationAddressStep data={data} errors={errors} onChange={updateField} />}
 
-      <div className="field-group">
-        <Paragraph text="Email address" />
-        <InputField
-          value={email}
-          onChange={(v) => {
-            setEmail(v);
-            if (emailError) validateEmail(v);
-          }}
-          isValid={!emailError}
-          placeholder="you@example.com"
-          icon={<FaEnvelope />}
-        />
-        {emailError && <Paragraph text={emailError} isError />}
-      </div>
+        <div className="registration-form__server-error">{authError && <p role="alert">{authError}</p>}</div>
 
-      <div className="field-group">
-        <Paragraph text="Password" />
-        <InputField
-          value={password}
-          onChange={(v) => {
-            setPassword(v);
-            if (passwordError) validatePassword(v);
-          }}
-          isValid={!passwordError}
-          placeholder="Enter your password"
-          type={showPassword ? "text" : "password"}
-          icon={<FaLock />}
-          rightIcon={
-            <span onClick={toggleShowPassword} style={{ cursor: "pointer" }}>
-              {showPassword ? <FaEyeSlash /> : <FaEye />}
-            </span>
-          }
-        />
-        {passwordError && <Paragraph text={passwordError} isError />}
-      </div>
+        <div className="registration-form__actions">
+          {currentStep > 0 && <Button disabled={isSubmitting} onClick={goBack} text="Back" variant="light" />}
+          <Button
+            disabled={isSubmitting}
+            text={currentStep === 2 ? (isSubmitting ? "Creating account…" : "Create account") : "Continue"}
+            type="submit"
+          />
+        </div>
 
-      <div className="field-group">
-        <Paragraph text="Confirm password" />
-        <InputField
-          value={confirmPassword}
-          onChange={(v) => {
-            setConfirmPassword(v);
-            if (confirmPasswordError) validateConfirmPassword(v);
-          }}
-          isValid={!confirmPasswordError}
-          placeholder="Re-enter your password"
-          type={showPassword ? "text" : "password"}
-          icon={<FaLock />}
-          rightIcon={
-            <span onClick={toggleShowPassword} style={{ cursor: "pointer" }}>
-              {showPassword ? <FaEyeSlash /> : <FaEye />}
-            </span>
-          }
-        />
-        {confirmPasswordError && <Paragraph text={confirmPasswordError} isError />}
-      </div>
-
-      <div className="field-group">
-        <Paragraph text="Date of birth" />
-        <InputField
-          value={dob}
-          onChange={(v) => {
-            setDob(v);
-            if (dobError) setDobError(validateDateOfBirth(v) || "");
-          }}
-          isValid={!dobError}
-          placeholder="YYYY-MM-DD"
-          type="date"
-          icon={<FaCalendar />}
-        />
-        {dobError && <Paragraph text={dobError} isError />}
-      </div>
-
-      <div className="field-group">
-        <Paragraph text="Street" />
-        <InputField
-          value={street}
-          onChange={(v) => {
-            setStreet(v);
-            if (streetError) setStreetError(validateStreet(v) || "");
-          }}
-          isValid={!streetError}
-          placeholder="Enter street address"
-          icon={<FaMapMarkerAlt />}
-        />
-        {streetError && <Paragraph text={streetError} isError />}
-      </div>
-
-      <div className="field-group">
-        <Paragraph text="City" />
-        <InputField
-          value={city}
-          onChange={(v) => {
-            setCity(v);
-            if (cityError) setCityError(validateCity(v) || "");
-          }}
-          isValid={!cityError}
-          placeholder="Brussels"
-          icon={<FaMapMarkerAlt />}
-        />
-        {cityError && <Paragraph text={cityError} isError />}
-      </div>
-
-      <div className="field-group">
-        <Paragraph text="Postal code" />
-        <InputField
-          value={postalCode}
-          onChange={(v) => {
-            setPostalCode(v);
-            if (postalCodeError) setPostalCodeError(validatePostalCode(v) || "");
-          }}
-          isValid={!postalCodeError}
-          placeholder="Enter postal code (4–5 digits)"
-          icon={<FaMapMarkerAlt />}
-        />
-        {postalCodeError && <Paragraph text={postalCodeError} isError />}
-      </div>
-
-      <div className="field-group">
-        <Paragraph text="Country" />
-        <select
-          value={country}
-          onChange={(e) => {
-            setCountry(e.target.value);
-            if (countryError) setCountryError(validateCountry(e.target.value) || "");
-          }}
-          className={`input ${!countryError ? "" : "input--error"}`}
-        >
-          {countryOptions.map((option) => (
-            <option key={option.value} value={option.value}>
-              {option.label}
-            </option>
-          ))}
-        </select>
-        {countryError && <Paragraph text={countryError} isError />}
-      </div>
-      <div className="field-group-def-adress">
-        <Paragraph text="Set adress as default billing and shipping adress:" />
-        <InputField
-          value="check"
-          type="checkbox"
-          onChange={() => {
-            setAsDefaultAdress(!isDefaultAdress);
-          }}
-        ></InputField>
-      </div>
-      <Button className="register-btn" text="Sign up" onClick={handleRegister} />
-      {authError && <Paragraph text={authError} isError className="auth-error-msg" />}
-
-      <Link
-        className="login-link"
-        text="Already have an account? Log in"
-        onClick={(e) => {
-          e.preventDefault();
-          navigate("/login");
-        }}
-        href={"/login"}
-      />
-    </div>
+        <p className="registration-form__login-link">
+          <span>Already have an account?</span> <Link to="/login">Log in</Link>
+        </p>
+      </form>
+    </AuthLayout>
   );
 }

--- a/frontend/src/pages/Registration/RegistrationSteps.tsx
+++ b/frontend/src/pages/Registration/RegistrationSteps.tsx
@@ -1,0 +1,240 @@
+import { FaCalendar, FaEnvelope, FaLock, FaMapMarkerAlt, FaUser } from "react-icons/fa";
+
+import { AuthFormField } from "../../components/Auth/AuthFormField/AuthFormField";
+import { PasswordVisibilityButton } from "../../components/common/PasswordVisibilityButton/PasswordVisibilityButton";
+import InputField from "../../components/common/inputField/inputField";
+import {
+  COUNTRY_OPTIONS,
+  REGISTRATION_FIELD_IDS,
+  type RegistrationErrors,
+  type RegistrationField,
+  type RegistrationFormData,
+} from "./registrationForm";
+
+export type RegistrationUpdate = <Field extends RegistrationField>(
+  field: Field,
+  value: RegistrationFormData[Field]
+) => void;
+
+type RegistrationStepProps = {
+  data: RegistrationFormData;
+  errors: RegistrationErrors;
+  onChange: RegistrationUpdate;
+};
+
+type AccountStepProps = RegistrationStepProps & {
+  confirmPasswordVisible: boolean;
+  onToggleConfirmPassword: () => void;
+  onTogglePassword: () => void;
+  passwordVisible: boolean;
+};
+
+function describedBy(field: RegistrationField) {
+  return `${REGISTRATION_FIELD_IDS[field]}-error`;
+}
+
+export function RegistrationAccountStep({
+  confirmPasswordVisible,
+  data,
+  errors,
+  onChange,
+  onToggleConfirmPassword,
+  onTogglePassword,
+  passwordVisible,
+}: AccountStepProps) {
+  return (
+    <div className="registration-form__step registration-form__step--account">
+      <div className="registration-form__name-fields">
+        <AuthFormField error={errors.firstName} inputId={REGISTRATION_FIELD_IDS.firstName} label="First name">
+          <InputField
+            aria-describedby={describedBy("firstName")}
+            autoComplete="given-name"
+            icon={<FaUser />}
+            id={REGISTRATION_FIELD_IDS.firstName}
+            isValid={!errors.firstName}
+            name="firstName"
+            onChange={(value) => onChange("firstName", value)}
+            placeholder="John"
+            value={data.firstName}
+          />
+        </AuthFormField>
+
+        <AuthFormField error={errors.lastName} inputId={REGISTRATION_FIELD_IDS.lastName} label="Last name">
+          <InputField
+            aria-describedby={describedBy("lastName")}
+            autoComplete="family-name"
+            icon={<FaUser />}
+            id={REGISTRATION_FIELD_IDS.lastName}
+            isValid={!errors.lastName}
+            name="lastName"
+            onChange={(value) => onChange("lastName", value)}
+            placeholder="Doe"
+            value={data.lastName}
+          />
+        </AuthFormField>
+      </div>
+
+      <AuthFormField error={errors.email} inputId={REGISTRATION_FIELD_IDS.email} label="Email address">
+        <InputField
+          aria-describedby={describedBy("email")}
+          autoComplete="email"
+          icon={<FaEnvelope />}
+          id={REGISTRATION_FIELD_IDS.email}
+          inputMode="email"
+          isValid={!errors.email}
+          name="email"
+          onChange={(value) => onChange("email", value)}
+          placeholder="you@example.com"
+          type="email"
+          value={data.email}
+        />
+      </AuthFormField>
+
+      <AuthFormField error={errors.password} inputId={REGISTRATION_FIELD_IDS.password} label="Password">
+        <InputField
+          aria-describedby={`${describedBy("password")} registration-password-help`}
+          autoComplete="new-password"
+          icon={<FaLock />}
+          id={REGISTRATION_FIELD_IDS.password}
+          isValid={!errors.password}
+          name="password"
+          onChange={(value) => onChange("password", value)}
+          placeholder="Create a password"
+          rightIcon={<PasswordVisibilityButton isVisible={passwordVisible} onToggle={onTogglePassword} />}
+          type={passwordVisible ? "text" : "password"}
+          value={data.password}
+        />
+        <p className="registration-form__help" id="registration-password-help">
+          At least 8 characters with uppercase, lowercase, number and special character.
+        </p>
+      </AuthFormField>
+
+      <AuthFormField
+        error={errors.confirmPassword}
+        inputId={REGISTRATION_FIELD_IDS.confirmPassword}
+        label="Confirm password"
+      >
+        <InputField
+          aria-describedby={describedBy("confirmPassword")}
+          autoComplete="new-password"
+          icon={<FaLock />}
+          id={REGISTRATION_FIELD_IDS.confirmPassword}
+          isValid={!errors.confirmPassword}
+          name="confirmPassword"
+          onChange={(value) => onChange("confirmPassword", value)}
+          placeholder="Repeat your password"
+          rightIcon={<PasswordVisibilityButton isVisible={confirmPasswordVisible} onToggle={onToggleConfirmPassword} />}
+          type={confirmPasswordVisible ? "text" : "password"}
+          value={data.confirmPassword}
+        />
+      </AuthFormField>
+    </div>
+  );
+}
+
+export function RegistrationPersonalStep({ data, errors, onChange }: RegistrationStepProps) {
+  return (
+    <div className="registration-form__step registration-form__step--personal">
+      <div className="registration-form__step-intro">
+        <h2>A little about you</h2>
+        <p>We use your date of birth only to confirm that you meet the minimum age requirement.</p>
+      </div>
+
+      <AuthFormField error={errors.dateOfBirth} inputId={REGISTRATION_FIELD_IDS.dateOfBirth} label="Date of birth">
+        <InputField
+          aria-describedby={describedBy("dateOfBirth")}
+          autoComplete="bday"
+          icon={<FaCalendar />}
+          id={REGISTRATION_FIELD_IDS.dateOfBirth}
+          isValid={!errors.dateOfBirth}
+          name="dateOfBirth"
+          onChange={(value) => onChange("dateOfBirth", value)}
+          type="date"
+          value={data.dateOfBirth}
+        />
+      </AuthFormField>
+    </div>
+  );
+}
+
+export function RegistrationAddressStep({ data, errors, onChange }: RegistrationStepProps) {
+  return (
+    <div className="registration-form__step registration-form__step--address">
+      <div className="registration-form__step-intro">
+        <h2>Your address</h2>
+        <p>Add the address you want to use for future deliveries and billing.</p>
+      </div>
+
+      <AuthFormField error={errors.street} inputId={REGISTRATION_FIELD_IDS.street} label="Street address">
+        <InputField
+          aria-describedby={describedBy("street")}
+          autoComplete="street-address"
+          icon={<FaMapMarkerAlt />}
+          id={REGISTRATION_FIELD_IDS.street}
+          isValid={!errors.street}
+          name="street"
+          onChange={(value) => onChange("street", value)}
+          placeholder="10 Main Street"
+          value={data.street}
+        />
+      </AuthFormField>
+
+      <div className="registration-form__address-row">
+        <AuthFormField error={errors.city} inputId={REGISTRATION_FIELD_IDS.city} label="City">
+          <InputField
+            aria-describedby={describedBy("city")}
+            autoComplete="address-level2"
+            id={REGISTRATION_FIELD_IDS.city}
+            isValid={!errors.city}
+            name="city"
+            onChange={(value) => onChange("city", value)}
+            placeholder="Berlin"
+            value={data.city}
+          />
+        </AuthFormField>
+
+        <AuthFormField error={errors.postalCode} inputId={REGISTRATION_FIELD_IDS.postalCode} label="Postal code">
+          <InputField
+            aria-describedby={describedBy("postalCode")}
+            autoComplete="postal-code"
+            id={REGISTRATION_FIELD_IDS.postalCode}
+            isValid={!errors.postalCode}
+            name="postalCode"
+            onChange={(value) => onChange("postalCode", value)}
+            placeholder="10115"
+            value={data.postalCode}
+          />
+        </AuthFormField>
+      </div>
+
+      <AuthFormField error={errors.country} inputId={REGISTRATION_FIELD_IDS.country} label="Country">
+        <select
+          aria-describedby={describedBy("country")}
+          aria-invalid={Boolean(errors.country)}
+          autoComplete="country"
+          className={`input${errors.country ? " input--error" : ""}`}
+          id={REGISTRATION_FIELD_IDS.country}
+          name="country"
+          onChange={(event) => onChange("country", event.currentTarget.value)}
+          value={data.country}
+        >
+          {COUNTRY_OPTIONS.map(([value, label]) => (
+            <option key={value || "placeholder"} value={value}>
+              {label}
+            </option>
+          ))}
+        </select>
+      </AuthFormField>
+
+      <label className="registration-form__default-address">
+        <input
+          checked={data.useAsDefaultAddress}
+          name="useAsDefaultAddress"
+          onChange={(event) => onChange("useAsDefaultAddress", event.currentTarget.checked)}
+          type="checkbox"
+        />
+        <span>Use as default billing and shipping address</span>
+      </label>
+    </div>
+  );
+}

--- a/frontend/src/pages/Registration/registrationForm.spec.ts
+++ b/frontend/src/pages/Registration/registrationForm.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  hasRegistrationErrors,
+  INITIAL_REGISTRATION_FORM,
+  validateRegistrationStep,
+  type RegistrationFormData,
+} from "./registrationForm";
+
+const validForm: RegistrationFormData = {
+  firstName: "Alex",
+  lastName: "Morgan",
+  email: "alex@example.com",
+  password: "Strong!Pass1",
+  confirmPassword: "Strong!Pass1",
+  dateOfBirth: "1995-05-15",
+  street: "10 Main Street",
+  city: "Berlin",
+  postalCode: "10115",
+  country: "DE",
+  useAsDefaultAddress: true,
+};
+
+describe("registration form validation", () => {
+  it("validates only account fields on the first step", () => {
+    const errors = validateRegistrationStep(0, INITIAL_REGISTRATION_FORM);
+
+    expect(errors.firstName).toBe("First name is required.");
+    expect(errors.email).toContain("'@' symbol");
+    expect(errors.password).toBe("Password must be at least 8 characters.");
+    expect(errors).not.toHaveProperty("dateOfBirth");
+    expect(errors).not.toHaveProperty("street");
+  });
+
+  it("detects a confirmation mismatch independently", () => {
+    const errors = validateRegistrationStep(0, { ...validForm, confirmPassword: "Different!Pass1" });
+
+    expect(errors.confirmPassword).toBe("Passwords do not match.");
+    expect(errors.firstName).toBeUndefined();
+  });
+
+  it("validates personal details and address on their own steps", () => {
+    expect(validateRegistrationStep(1, INITIAL_REGISTRATION_FORM).dateOfBirth).toBe("Date of birth is required.");
+    expect(validateRegistrationStep(2, INITIAL_REGISTRATION_FORM)).toMatchObject({
+      street: "Street is required.",
+      city: "City is required.",
+      postalCode: "Postal code is required.",
+      country: "Please select a country.",
+    });
+  });
+
+  it("accepts a complete valid form", () => {
+    expect(hasRegistrationErrors(validateRegistrationStep(0, validForm))).toBe(false);
+    expect(hasRegistrationErrors(validateRegistrationStep(1, validForm))).toBe(false);
+    expect(hasRegistrationErrors(validateRegistrationStep(2, validForm))).toBe(false);
+  });
+});

--- a/frontend/src/pages/Registration/registrationForm.ts
+++ b/frontend/src/pages/Registration/registrationForm.ts
@@ -47,6 +47,20 @@ export const STEP_FIELDS: Record<RegistrationStep, RegistrationField[]> = {
   2: ["street", "city", "postalCode", "country"],
 };
 
+export const REGISTRATION_FIELD_IDS: Record<RegistrationField, string> = {
+  firstName: "registration-first-name",
+  lastName: "registration-last-name",
+  email: "registration-email",
+  password: "registration-password",
+  confirmPassword: "registration-confirm-password",
+  dateOfBirth: "registration-date-of-birth",
+  street: "registration-street",
+  city: "registration-city",
+  postalCode: "registration-postal-code",
+  country: "registration-country",
+  useAsDefaultAddress: "registration-default-address",
+};
+
 export const COUNTRY_OPTIONS = [
   ["", "Select a country"],
   ["AT", "Austria"],

--- a/frontend/src/pages/Registration/registrationForm.ts
+++ b/frontend/src/pages/Registration/registrationForm.ts
@@ -1,0 +1,110 @@
+import {
+  validateCity,
+  validateCountry,
+  validateDateOfBirth,
+  validateEmailFormat,
+  validateName,
+  validatePasswordStrength,
+  validatePostalCode,
+  validateStreet,
+} from "../../utils/validation";
+
+export type RegistrationFormData = {
+  firstName: string;
+  lastName: string;
+  email: string;
+  password: string;
+  confirmPassword: string;
+  dateOfBirth: string;
+  street: string;
+  city: string;
+  postalCode: string;
+  country: string;
+  useAsDefaultAddress: boolean;
+};
+
+export type RegistrationField = keyof RegistrationFormData;
+export type RegistrationErrors = Partial<Record<RegistrationField, string>>;
+export type RegistrationStep = 0 | 1 | 2;
+
+export const INITIAL_REGISTRATION_FORM: RegistrationFormData = {
+  firstName: "",
+  lastName: "",
+  email: "",
+  password: "",
+  confirmPassword: "",
+  dateOfBirth: "",
+  street: "",
+  city: "",
+  postalCode: "",
+  country: "",
+  useAsDefaultAddress: false,
+};
+
+export const STEP_FIELDS: Record<RegistrationStep, RegistrationField[]> = {
+  0: ["firstName", "lastName", "email", "password", "confirmPassword"],
+  1: ["dateOfBirth"],
+  2: ["street", "city", "postalCode", "country"],
+};
+
+export const COUNTRY_OPTIONS = [
+  ["", "Select a country"],
+  ["AT", "Austria"],
+  ["BE", "Belgium"],
+  ["BG", "Bulgaria"],
+  ["HR", "Croatia"],
+  ["CY", "Cyprus"],
+  ["CZ", "Czech Republic"],
+  ["DK", "Denmark"],
+  ["EE", "Estonia"],
+  ["FI", "Finland"],
+  ["FR", "France"],
+  ["DE", "Germany"],
+  ["GR", "Greece"],
+  ["HU", "Hungary"],
+  ["IE", "Ireland"],
+  ["IT", "Italy"],
+  ["LV", "Latvia"],
+  ["LT", "Lithuania"],
+  ["LU", "Luxembourg"],
+  ["MT", "Malta"],
+  ["NL", "Netherlands"],
+  ["PL", "Poland"],
+  ["PT", "Portugal"],
+  ["RO", "Romania"],
+  ["SK", "Slovakia"],
+  ["SI", "Slovenia"],
+  ["ES", "Spain"],
+  ["SE", "Sweden"],
+] as const;
+
+function errorMessage(result: string | null) {
+  return result ?? undefined;
+}
+
+export function validateRegistrationStep(step: RegistrationStep, data: RegistrationFormData): RegistrationErrors {
+  if (step === 0) {
+    return {
+      firstName: errorMessage(validateName(data.firstName, "First name")),
+      lastName: errorMessage(validateName(data.lastName, "Last name")),
+      email: errorMessage(validateEmailFormat(data.email)),
+      password: errorMessage(validatePasswordStrength(data.password)),
+      confirmPassword: data.confirmPassword === data.password ? undefined : "Passwords do not match.",
+    };
+  }
+
+  if (step === 1) {
+    return { dateOfBirth: errorMessage(validateDateOfBirth(data.dateOfBirth)) };
+  }
+
+  return {
+    street: errorMessage(validateStreet(data.street)),
+    city: errorMessage(validateCity(data.city)),
+    postalCode: errorMessage(validatePostalCode(data.postalCode)),
+    country: errorMessage(validateCountry(data.country)),
+  };
+}
+
+export function hasRegistrationErrors(errors: RegistrationErrors) {
+  return Object.values(errors).some(Boolean);
+}

--- a/frontend/src/utils/validation.spec.ts
+++ b/frontend/src/utils/validation.spec.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+
+import { validatePasswordStrength } from "./validation";
+
+describe("validatePasswordStrength", () => {
+  it("accepts an underscore as the required special character", () => {
+    expect(validatePasswordStrength("Strong_Pass1")).toBeNull();
+  });
+
+  it("rejects characters outside the supported password alphabet", () => {
+    expect(validatePasswordStrength("Strong/Pass1!")).toBe("Password contains invalid characters.");
+  });
+});

--- a/frontend/src/utils/validation.ts
+++ b/frontend/src/utils/validation.ts
@@ -40,8 +40,8 @@ export const validatePasswordStrength = (value: string): string | null => {
   if (!/[A-Z]/.test(value)) return "Password must include at least one uppercase letter.";
   if (!/[a-z]/.test(value)) return "Password must include at least one lowercase letter.";
   if (!/[0-9]/.test(value)) return "Password must include at least one digit.";
-  if (!/[!@#$%^&*(),.?":{}|<>]/.test(value)) return "Password must include at least one special character.";
-  if (!/^[A-Za-z0-9!@#$%^&*(),.?":{}|<>]+$/.test(value)) return "Password contains invalid characters.";
+  if (!/[!@#$%^&*(),.?":{}|<>_]/.test(value)) return "Password must include at least one special character.";
+  if (!/^[A-Za-z0-9!@#$%^&*(),.?":{}|<>_]+$/.test(value)) return "Password contains invalid characters.";
   return null;
 };
 


### PR DESCRIPTION
## Summary

- redesign the sign-up page as a modern, responsive three-step flow
- add reusable accessible form-field and registration-progress components
- preserve entered data between steps and validate only the active step
- use compact independent password visibility controls
- prevent layout shifts when long validation or API errors appear
- update the storefront smoke test for the new registration journey

## Why

The previous registration screen presented every field at once and no longer matched the visual language established by the redesigned storefront and login page. The new flow reduces cognitive load while keeping the existing registration API contract unchanged.

## User impact

Users now create an account through Account, Personal details, and Address steps. The form works without adjacent imagery, adapts to mobile widths, keeps values when navigating back, focuses the first invalid field, and remains visually stable when errors are shown.

## Validation

- `npm test` — 116 frontend and 17 backend tests passed
- `npm run build` — frontend and backend production builds passed
- `npm run lint`
- `npm run format:check`
- `npm run test:smoke` — 3 Playwright scenarios passed
- manual visual QA at 1440 × 1000 and 390 × 844