### PR TITLE
feat(frontend): improve account state and logout experience

### DIFF
--- a/e2e/store.spec.ts
+++ b/e2e/store.spec.ts
@@ -21,7 +21,9 @@ test("registers, shops with a promo code, opens profile and logs out", async ({ 
   await page.getByRole("checkbox", { name: "Use as default billing and shipping address" }).check();
   await page.getByRole("button", { name: "Create account" }).click();
 
-  await expect(page.getByRole("link", { name: "Open profile" })).toBeVisible();
+  const accountLink = page.getByRole("link", { name: "Open Playwright's account" });
+  await expect(accountLink).toContainText("PU");
+  await expect(accountLink).toContainText("Hi, Playwright");
   await page.getByRole("link", { name: "Catalog" }).click();
   await page.getByRole("button", { name: "Add to Cart" }).first().click();
 
@@ -33,7 +35,7 @@ test("registers, shops with a promo code, opens profile and logs out", async ({ 
   await expect(page.getByLabel("Applied promo code")).toContainText("WELCOME10");
   await expect(page.getByText("Discount", { exact: true })).toBeVisible();
 
-  await page.getByRole("link", { name: "Open profile" }).click();
+  await accountLink.click();
   await expect(page.getByRole("heading", { level: 1, name: "My account" })).toBeVisible();
   const personalDetailsRegion = page.getByRole("region", { name: "Personal details" });
   await expect(personalDetailsRegion).toBeVisible();
@@ -55,6 +57,14 @@ test("registers, shops with a promo code, opens profile and logs out", async ({ 
   await page.getByRole("button", { name: "Log out" }).click();
   await expect(page).toHaveURL(/\/login$/);
   await expect(page.getByRole("heading", { name: "Welcome back" })).toBeVisible();
+
+  const signedOutAccountLink = page.getByLabel("Sign in", { exact: true });
+  await expect(signedOutAccountLink).toContainText("Your account");
+
+  const emptyCartLink = page.getByRole("link", { name: "Shopping cart, empty" });
+  await expect(emptyCartLink).toBeVisible();
+  await emptyCartLink.click();
+  await expect(page.getByRole("heading", { name: "Your cart is empty" })).toBeVisible();
 });
 
 test("manages product quantity and a promo code in the cart", async ({ page }) => {

--- a/frontend/src/components/Header/Header.spec.tsx
+++ b/frontend/src/components/Header/Header.spec.tsx
@@ -52,7 +52,7 @@ describe("Header", () => {
     expect(screen.getByRole("navigation", { name: "Primary navigation" })).toBeInTheDocument();
     expect(screen.getByRole("search", { name: "Product search" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Shopping cart, empty" })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "Log in" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Sign in" })).toBeInTheDocument();
   });
 
   it("opens one mobile panel at a time and manages scroll locking", () => {

--- a/frontend/src/components/Header/HeaderActions/HeaderActions.scss
+++ b/frontend/src/components/Header/HeaderActions/HeaderActions.scss
@@ -1,3 +1,5 @@
+@use "../../../assets/styles/tokens" as tokens;
+
 .header-actions {
   display: flex;
   align-items: center;
@@ -25,6 +27,127 @@
 
   &:active {
     transform: scale(0.94);
+  }
+}
+
+.header-actions__account {
+  display: inline-flex;
+  width: 13.6rem;
+  min-height: 4.8rem;
+  padding: var(--space-1) var(--space-2);
+  align-items: center;
+  gap: var(--space-2);
+  border-radius: var(--radius-sm);
+  color: var(--color-ink);
+  text-decoration: none;
+  transition:
+    background-color var(--transition-fast),
+    transform var(--transition-fast);
+
+  &:hover {
+    background-color: var(--color-surface-subtle);
+  }
+
+  &:active {
+    transform: scale(0.98);
+  }
+}
+
+.header-actions__account-copy {
+  display: grid;
+  min-width: 0;
+  line-height: var(--line-height-body);
+
+  strong,
+  > span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  strong {
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-medium);
+  }
+
+  > span {
+    color: var(--color-text-muted);
+    font-size: var(--font-size-xs);
+  }
+}
+
+.header-actions__avatar,
+.header-actions__account-placeholder {
+  display: inline-flex;
+  width: 3.6rem;
+  height: 3.6rem;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  border-radius: var(--radius-pill);
+}
+
+.header-actions__avatar {
+  background-color: var(--color-ink);
+  color: var(--color-surface);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  letter-spacing: 0.04em;
+}
+
+.header-actions__account--loading {
+  pointer-events: none;
+}
+
+.header-actions__account-placeholder,
+.header-actions__placeholder-line {
+  background-color: var(--color-surface-subtle);
+  animation: header-account-pulse 1.4s ease-in-out infinite;
+}
+
+.header-actions__placeholder-line {
+  width: 6.4rem;
+  height: 0.8rem;
+  border-radius: var(--radius-pill);
+}
+
+.header-actions__placeholder-line--primary {
+  width: 7.6rem;
+  height: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+@keyframes header-account-pulse {
+  50% {
+    opacity: 0.45;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .header-actions__account-placeholder,
+  .header-actions__placeholder-line {
+    animation: none;
+  }
+}
+
+@media (max-width: tokens.$breakpoint-tablet) {
+  .header-actions__account {
+    width: 4rem;
+    min-width: 4rem;
+    min-height: 4rem;
+    padding: 0;
+    justify-content: center;
+    border-radius: var(--radius-pill);
+  }
+
+  .header-actions__account-copy {
+    display: none;
+  }
+
+  .header-actions__avatar,
+  .header-actions__account-placeholder {
+    width: 3.2rem;
+    height: 3.2rem;
   }
 }
 

--- a/frontend/src/components/Header/HeaderActions/HeaderActions.spec.tsx
+++ b/frontend/src/components/Header/HeaderActions/HeaderActions.spec.tsx
@@ -6,11 +6,20 @@ import { AuthContext, type AuthContextValue } from "../../context/AuthContext";
 import { CartContext, type CartContextType } from "../../context/CartContext";
 import { HeaderActions } from "./HeaderActions";
 
-function renderActions({ isAuthenticated = false, quantity = 0 } = {}) {
+const customer = {
+  id: "customer-id",
+  email: "yevhen@example.com",
+  firstName: "Yevhen",
+  lastName: "Ryhus",
+  dateOfBirth: "1993-05-14",
+  addresses: [],
+};
+
+function renderActions({ isAuthenticated = false, loading = false, quantity = 0 } = {}) {
   const authValue: AuthContextValue = {
-    user: null,
+    user: isAuthenticated ? customer : null,
     isAuthenticated,
-    loading: false,
+    loading,
     refreshUser: vi.fn(),
     logout: vi.fn(),
   };
@@ -46,13 +55,22 @@ describe("HeaderActions", () => {
     renderActions();
 
     expect(screen.getByRole("link", { name: "Shopping cart, empty" })).toHaveAttribute("href", "/basket");
-    expect(screen.getByRole("link", { name: "Log in" })).toHaveAttribute("href", "/login");
+    expect(screen.getByRole("link", { name: "Sign in" })).toHaveAttribute("href", "/login");
+    expect(screen.getByRole("link", { name: "Sign in" })).toHaveTextContent("Sign inYour account");
   });
 
-  it("links authenticated users to profile and displays the cart quantity", () => {
+  it("shows the authenticated customer identity and cart quantity", () => {
     renderActions({ isAuthenticated: true, quantity: 3 });
 
     expect(screen.getByRole("link", { name: "Shopping cart, 3 items" })).toHaveTextContent("3");
-    expect(screen.getByRole("link", { name: "Open profile" })).toHaveAttribute("href", "/profile");
+    expect(screen.getByRole("link", { name: "Open Yevhen's account" })).toHaveAttribute("href", "/profile");
+    expect(screen.getByRole("link", { name: "Open Yevhen's account" })).toHaveTextContent("YRHi, YevhenMy account");
+  });
+
+  it("does not expose the wrong account destination while authentication is loading", () => {
+    renderActions({ loading: true });
+
+    expect(screen.getByRole("status", { name: "Checking account status" })).toBeVisible();
+    expect(screen.queryByRole("link", { name: "Sign in" })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/Header/HeaderActions/HeaderActions.tsx
+++ b/frontend/src/components/Header/HeaderActions/HeaderActions.tsx
@@ -10,16 +10,19 @@ import "./HeaderActions.scss";
 type HeaderActionsProps = Omit<ComponentPropsWithoutRef<"div">, "children">;
 
 export function HeaderActions({ className = "", ...props }: HeaderActionsProps) {
-  const { isAuthenticated } = useAuth();
+  const { isAuthenticated, loading, user } = useAuth();
   const { calculateTotalQuantity } = useCart();
   const totalQuantity = calculateTotalQuantity();
   const cartLabel = totalQuantity > 0 ? `Shopping cart, ${totalQuantity} items` : "Shopping cart, empty";
-  const accountLabel = isAuthenticated ? "Open profile" : "Log in";
+  const firstName = user?.firstName?.trim() ?? "";
+  const lastName = user?.lastName?.trim() ?? "";
+  const initials = `${firstName.charAt(0)}${lastName.charAt(0)}`.toUpperCase() || user?.email.charAt(0).toUpperCase();
+  const accountLabel = isAuthenticated ? (firstName ? `Open ${firstName}'s account` : "Open your account") : "Sign in";
   const classes = `header-actions ${className}`.trim();
 
   return (
     <div {...props} className={classes}>
-      <Link aria-label={cartLabel} className="header-actions__link" to="/basket">
+      <Link aria-label={cartLabel} className="header-actions__link header-actions__cart" to="/basket">
         <span aria-hidden="true" className="header-actions__icon">
           <PiShoppingCartSimple />
         </span>
@@ -29,11 +32,39 @@ export function HeaderActions({ className = "", ...props }: HeaderActionsProps) 
           </span>
         )}
       </Link>
-      <Link aria-label={accountLabel} className="header-actions__link" to={isAuthenticated ? "/profile" : "/login"}>
-        <span aria-hidden="true" className="header-actions__icon">
-          <PiUserCircle />
+      {loading ? (
+        <span
+          aria-label="Checking account status"
+          className="header-actions__account header-actions__account--loading"
+          role="status"
+        >
+          <span aria-hidden="true" className="header-actions__account-placeholder" />
+          <span aria-hidden="true" className="header-actions__account-copy">
+            <span className="header-actions__placeholder-line header-actions__placeholder-line--primary" />
+            <span className="header-actions__placeholder-line" />
+          </span>
         </span>
-      </Link>
+      ) : (
+        <Link
+          aria-label={accountLabel}
+          className="header-actions__account"
+          to={isAuthenticated ? "/profile" : "/login"}
+        >
+          {isAuthenticated ? (
+            <span aria-hidden="true" className="header-actions__avatar">
+              {initials}
+            </span>
+          ) : (
+            <span aria-hidden="true" className="header-actions__icon">
+              <PiUserCircle />
+            </span>
+          )}
+          <span className="header-actions__account-copy">
+            <strong>{isAuthenticated ? (firstName ? `Hi, ${firstName}` : "My account") : "Sign in"}</strong>
+            <span>{isAuthenticated ? "My account" : "Your account"}</span>
+          </span>
+        </Link>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/User/User.spec.tsx
+++ b/frontend/src/pages/User/User.spec.tsx
@@ -1,0 +1,61 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useAuth } from "../../components/context/useAuth";
+import { useCart } from "../../components/context/useCart";
+import type { CustomerResponse } from "../../services/customerService/types";
+import UserPage from "./User";
+
+const navigate = vi.fn();
+const logout = vi.fn();
+const refreshCart = vi.fn();
+const setNewCart = vi.fn();
+
+const customer: CustomerResponse = {
+  id: "customer-id",
+  email: "yevhen@example.com",
+  firstName: "Yevhen",
+  lastName: "Ryhus",
+  dateOfBirth: "1993-05-14",
+  addresses: [],
+  shippingAddressIds: [],
+  billingAddressIds: [],
+  defaultBillingAddressId: null,
+  defaultShippingAddressId: null,
+};
+
+vi.mock("react-router-dom", () => ({
+  useLoaderData: () => customer,
+  useNavigate: () => navigate,
+}));
+
+vi.mock("../../components/context/useAuth", () => ({ useAuth: vi.fn() }));
+vi.mock("../../components/context/useCart", () => ({ useCart: vi.fn() }));
+vi.mock("../../components/UserInfo/UserInfo", () => ({
+  UserInfo: ({ onLogout }: { onLogout: () => Promise<void> }) => (
+    <button onClick={() => void onLogout()} type="button">
+      Log out
+    </button>
+  ),
+}));
+
+describe("UserPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    logout.mockResolvedValue(undefined);
+    refreshCart.mockResolvedValue(undefined);
+    vi.mocked(useAuth).mockReturnValue({ logout } as never);
+    vi.mocked(useCart).mockReturnValue({ refreshCart, setNewCart } as never);
+  });
+
+  it("removes the authenticated cart immediately after a successful logout", async () => {
+    render(<UserPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Log out" }));
+
+    await waitFor(() => expect(logout).toHaveBeenCalledOnce());
+    await waitFor(() => expect(setNewCart).toHaveBeenCalledWith(null));
+    expect(navigate).toHaveBeenCalledWith("/login", { replace: true });
+    expect(refreshCart).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/pages/User/User.tsx
+++ b/frontend/src/pages/User/User.tsx
@@ -1,16 +1,20 @@
 import { useLoaderData, useNavigate } from "react-router-dom";
 import { UserInfo } from "../../components/UserInfo/UserInfo";
 import { useAuth } from "../../components/context/useAuth";
+import { useCart } from "../../components/context/useCart";
 import type { CustomerResponse } from "../../services/customerService/types";
 
 export default function UserPage() {
   const customer = useLoaderData() as CustomerResponse;
   const navigate = useNavigate();
   const { logout } = useAuth();
+  const { refreshCart, setNewCart } = useCart();
 
   const handleLogout = async () => {
     await logout();
+    setNewCart(null);
     navigate("/login", { replace: true });
+    void refreshCart();
   };
 
   const {


### PR DESCRIPTION
## Summary

- clear the client-side cart immediately after a successful logout and refresh a new anonymous cart in the background
- replace the ambiguous account icon with a dynamic guest, loading, or authenticated account label
- show customer initials and first name on desktop while keeping a compact, recognizable mobile state
- cover the complete registration, shopping, profile, logout, and empty-cart flow with Playwright

## Why

The previous logout flow revoked the session but left the authenticated cart in React state until the page was refreshed. The account icon also gave no visible indication of whether the visitor was signed in.

This change keeps the header and cart synchronized with authentication state immediately, without requiring a reload.

## UX and accessibility

- loading skeleton prevents a false guest state while `/auth/me` is pending
- account destinations retain explicit accessible labels
- reduced-motion preferences disable the skeleton animation
- mobile uses an outline icon for guests and a filled initials avatar for signed-in customers

## Validation

- frontend: 58 test files, 120 tests passed
- backend: 8 test files, 19 tests passed
- ESLint passed
- Prettier check passed
- frontend and backend production builds passed
- Playwright smoke flow passed for Dynamic label and immediate cart reset after logout
