### PR TITLE
fix(frontend): prevent auth page redirect flash

### DIFF
--- a/e2e/store.spec.ts
+++ b/e2e/store.spec.ts
@@ -24,6 +24,15 @@ test("registers, shops with a promo code, opens profile and logs out", async ({ 
   const accountLink = page.getByRole("link", { name: "Open Playwright's account" });
   await expect(accountLink).toContainText("PU");
   await expect(accountLink).toContainText("Hi, Playwright");
+
+  await page.goto("/login");
+  await expect(page).toHaveURL(/\/$/);
+  await expect(page.getByRole("heading", { name: "Welcome back" })).toHaveCount(0);
+
+  await page.goto("/sign-up");
+  await expect(page).toHaveURL(/\/$/);
+  await expect(page.getByRole("heading", { name: "Create your account" })).toHaveCount(0);
+
   await page.getByRole("link", { name: "Catalog" }).click();
   await page.getByRole("button", { name: "Add to Cart" }).first().click();
 

--- a/frontend/src/pages/Login/Login.tsx
+++ b/frontend/src/pages/Login/Login.tsx
@@ -1,4 +1,4 @@
-import { type FormEvent, useEffect, useRef, useState } from "react";
+import { type FormEvent, useRef, useState } from "react";
 import { FaEnvelope, FaLock } from "react-icons/fa";
 import { Link, useNavigate } from "react-router-dom";
 
@@ -14,15 +14,9 @@ import { validateEmailFormat } from "../../utils/validation";
 import "./Login.scss";
 
 export default function LoginPage() {
-  const { isAuthenticated, refreshUser } = useAuth();
+  const { refreshUser } = useAuth();
 
   const navigate = useNavigate();
-  useEffect(() => {
-    if (isAuthenticated) {
-      navigate("/");
-    }
-  }, [isAuthenticated, navigate]);
-
   const { setNewCart } = useCart();
   const [authError, setAuthError] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);

--- a/frontend/src/pages/Registration/Registration.tsx
+++ b/frontend/src/pages/Registration/Registration.tsx
@@ -26,7 +26,7 @@ import {
 import "./Registration.scss";
 
 export default function RegistrationPage() {
-  const { isAuthenticated, refreshUser } = useAuth();
+  const { refreshUser } = useAuth();
   const { setNewCart } = useCart();
   const navigate = useNavigate();
   const stepHeadingRef = useRef<HTMLHeadingElement>(null);
@@ -39,10 +39,6 @@ export default function RegistrationPage() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [passwordVisible, setPasswordVisible] = useState(false);
   const [confirmPasswordVisible, setConfirmPasswordVisible] = useState(false);
-
-  useEffect(() => {
-    if (isAuthenticated) navigate("/");
-  }, [isAuthenticated, navigate]);
 
   useEffect(() => {
     if (hasChangedStep.current) stepHeadingRef.current?.focus();

--- a/frontend/src/routes/guards/GuestOnlyRoute.scss
+++ b/frontend/src/routes/guards/GuestOnlyRoute.scss
@@ -1,0 +1,30 @@
+.guest-only-route__status {
+  display: flex;
+  min-height: 32rem;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+}
+
+.guest-only-route__spinner {
+  width: 1.8rem;
+  height: 1.8rem;
+  border: 0.2rem solid var(--color-border);
+  border-top-color: var(--color-ink);
+  border-radius: var(--radius-pill);
+  animation: guest-route-spin 0.7s linear infinite;
+}
+
+@keyframes guest-route-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .guest-only-route__spinner {
+    animation: none;
+  }
+}

--- a/frontend/src/routes/guards/GuestOnlyRoute.spec.tsx
+++ b/frontend/src/routes/guards/GuestOnlyRoute.spec.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useAuth } from "../../components/context/useAuth";
+import { GuestOnlyRoute } from "./GuestOnlyRoute";
+
+vi.mock("../../components/context/useAuth", () => ({ useAuth: vi.fn() }));
+
+function renderRoute() {
+  return render(
+    <MemoryRouter initialEntries={["/login"]}>
+      <Routes>
+        <Route element={<GuestOnlyRoute />}>
+          <Route element={<h1>Login form</h1>} path="login" />
+        </Route>
+        <Route element={<h1>Storefront</h1>} path="/" />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe("GuestOnlyRoute", () => {
+  beforeEach(() => {
+    vi.mocked(useAuth).mockReturnValue({ isAuthenticated: false, loading: false } as never);
+  });
+
+  it("renders the guest page after authentication has been checked", () => {
+    renderRoute();
+
+    expect(screen.getByRole("heading", { name: "Login form" })).toBeVisible();
+  });
+
+  it("does not render the guest page while authentication is loading", () => {
+    vi.mocked(useAuth).mockReturnValue({ isAuthenticated: false, loading: true } as never);
+
+    renderRoute();
+
+    expect(screen.getByRole("status")).toHaveTextContent("Checking your account");
+    expect(screen.queryByRole("heading", { name: "Login form" })).not.toBeInTheDocument();
+  });
+
+  it("redirects authenticated customers without rendering the guest page", () => {
+    vi.mocked(useAuth).mockReturnValue({ isAuthenticated: true, loading: false } as never);
+
+    renderRoute();
+
+    expect(screen.getByRole("heading", { name: "Storefront" })).toBeVisible();
+    expect(screen.queryByRole("heading", { name: "Login form" })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/routes/guards/GuestOnlyRoute.tsx
+++ b/frontend/src/routes/guards/GuestOnlyRoute.tsx
@@ -1,0 +1,21 @@
+import { Navigate, Outlet } from "react-router-dom";
+import { useAuth } from "../../components/context/useAuth";
+
+import "./GuestOnlyRoute.scss";
+
+export function GuestOnlyRoute() {
+  const { isAuthenticated, loading } = useAuth();
+
+  if (loading) {
+    return (
+      <div aria-live="polite" className="guest-only-route__status" role="status">
+        <span aria-hidden="true" className="guest-only-route__spinner" />
+        Checking your account…
+      </div>
+    );
+  }
+
+  if (isAuthenticated) return <Navigate replace to="/" />;
+
+  return <Outlet />;
+}

--- a/frontend/src/routes/routesConfig.tsx
+++ b/frontend/src/routes/routesConfig.tsx
@@ -12,6 +12,7 @@ import { loadCutomerData } from "./DataHandlers/Profile/ProfileLoaders";
 import { actionCustomerData } from "./DataHandlers/Profile/ProfileActions";
 import ProductPage from "../pages/Product/Product";
 import BasketPage from "../pages/Basket/Basket";
+import { GuestOnlyRoute } from "./guards/GuestOnlyRoute";
 
 const router = createBrowserRouter(
   [
@@ -20,8 +21,13 @@ const router = createBrowserRouter(
       Component: MainLayout,
       children: [
         { index: true, Component: HomePage },
-        { path: "login", Component: LoginPage },
-        { path: "sign-up", Component: RegistrationPage },
+        {
+          Component: GuestOnlyRoute,
+          children: [
+            { path: "login", Component: LoginPage },
+            { path: "sign-up", Component: RegistrationPage },
+          ],
+        },
         {
           path: "profile",
           loader: loadCutomerData,


### PR DESCRIPTION
## Summary

- add a shared guest-only route guard for Login and Sign-up
- wait for authentication bootstrap before mounting either auth form
- redirect authenticated customers to the storefront during render
- remove duplicate post-render redirect effects from both pages
- add unit and Playwright coverage for loading, guest, and authenticated states

## Root cause

Login and Sign-up previously checked `isAuthenticated` in `useEffect`. Effects run after the first render, so an authenticated customer could briefly see the auth form before navigation completed.

## User impact

Authenticated customers can open `/login` or `/sign-up` directly without seeing a flash of those pages. During the initial `/auth/me` request, the application displays a neutral account-checking state instead of rendering the wrong content.

## Validation

- GuestOnlyRoute, Login, and Registration tests passed: 16 tests
- frontend production build passed
- ESLint and Prettier checks passed
- all 3 Playwright smoke scenarios passed
