### PR TITLE
fix(frontend): prevent stale content during route loading

### DIFF
--- a/e2e/store.spec.ts
+++ b/e2e/store.spec.ts
@@ -113,6 +113,83 @@ test("manages product quantity and a promo code in the cart", async ({ page }) =
   await expect(page.getByRole("heading", { name: "Your cart is empty" })).toBeVisible();
 });
 
+test("hides stale catalog and product content while slow requests are pending", async ({ page }) => {
+  let delayNextCatalogRequest = false;
+  let catalogRequestBlocked = false;
+  let releaseCatalogRequest = () => {};
+  let delayNextProductRequest = false;
+  let productRequestBlocked = false;
+  let releaseProductRequest = () => {};
+
+  await page.route(/\/api\/v1\/catalog\/products(?:\?.*)?$/, async (route) => {
+    if (delayNextCatalogRequest) {
+      delayNextCatalogRequest = false;
+      catalogRequestBlocked = true;
+      await new Promise<void>((resolve) => {
+        releaseCatalogRequest = resolve;
+      });
+      catalogRequestBlocked = false;
+    }
+    await route.continue();
+  });
+
+  await page.route(/\/api\/v1\/catalog\/products\/[^/?]+(?:\?.*)?$/, async (route) => {
+    if (delayNextProductRequest) {
+      delayNextProductRequest = false;
+      productRequestBlocked = true;
+      await new Promise<void>((resolve) => {
+        releaseProductRequest = resolve;
+      });
+      productRequestBlocked = false;
+    }
+    await route.continue();
+  });
+
+  await page.goto("/catalog");
+  await expect(page.getByText("Showing 1-6 of 8 products")).toBeVisible();
+  const previousCatalogProduct = await page
+    .getByRole("link", { name: /^View / })
+    .first()
+    .getAttribute("aria-label");
+
+  delayNextCatalogRequest = true;
+  await page.getByRole("button", { name: "Next page" }).click();
+
+  await expect(page.getByRole("status", { name: "Catalog loading" })).toBeVisible();
+  await expect(page.getByRole("article")).toHaveCount(0);
+  await expect.poll(() => catalogRequestBlocked).toBe(true);
+  if (previousCatalogProduct) {
+    await expect(page.getByRole("link", { name: previousCatalogProduct })).toHaveCount(0);
+  }
+
+  releaseCatalogRequest();
+  await expect(page.getByText("Showing 7-8 of 8 products")).toBeVisible();
+
+  await page
+    .getByRole("link", { name: /^View / })
+    .first()
+    .click();
+  const currentProductHeading = page.locator(".product-page__main h1");
+  await expect(currentProductHeading).toBeVisible();
+  const previousProductName = await currentProductHeading.textContent();
+  const relatedProductLink = page.locator(".related-products .product-card__link").first();
+  await expect(relatedProductLink).toBeVisible();
+  const nextProductLabel = await relatedProductLink.getAttribute("aria-label");
+  if (!nextProductLabel) throw new Error("Related product link must have an accessible label.");
+
+  delayNextProductRequest = true;
+  await relatedProductLink.click();
+
+  await expect(page.getByRole("status", { name: "Product loading" })).toBeVisible();
+  await expect.poll(() => productRequestBlocked).toBe(true);
+  if (previousProductName) {
+    await expect(page.getByRole("heading", { name: previousProductName })).toHaveCount(0);
+  }
+
+  releaseProductRequest();
+  await expect(page.getByRole("heading", { name: nextProductLabel.replace(/^View /, "") })).toBeVisible();
+});
+
 test("opens the team page from the storefront navigation", async ({ page }) => {
   await page.goto("/");
 

--- a/frontend/src/pages/Category/Category.spec.tsx
+++ b/frontend/src/pages/Category/Category.spec.tsx
@@ -90,6 +90,28 @@ describe("CategoryPage", () => {
     expect(fetchProductPage).toHaveBeenLastCalledWith(expect.objectContaining({ limit: 6, offset: 6 }));
   });
 
+  it("hides results from the previous URL while the next page is loading", async () => {
+    let resolveNextPage!: (page: Awaited<ReturnType<typeof fetchProductPage>>) => void;
+    const nextPage = new Promise<Awaited<ReturnType<typeof fetchProductPage>>>((resolve) => {
+      resolveNextPage = resolve;
+    });
+
+    vi.mocked(fetchProductPage)
+      .mockResolvedValueOnce({ items: [product(1)], offset: 0, limit: 6, total: 8 })
+      .mockReturnValueOnce(nextPage);
+
+    renderCatalog();
+    expect(await screen.findByText("Product 1")).toBeVisible();
+
+    fireEvent.click(screen.getByRole("button", { name: "Next page" }));
+
+    expect(screen.getByRole("status", { name: "Catalog loading" })).toBeVisible();
+    expect(screen.queryByText("Product 1")).not.toBeInTheDocument();
+
+    resolveNextPage({ items: [product(7)], offset: 6, limit: 6, total: 8 });
+    expect(await screen.findByText("Product 7")).toBeVisible();
+  });
+
   it("stores sorting in the URL and exposes categories in the mobile drawer", async () => {
     renderCatalog();
 

--- a/frontend/src/pages/Category/Category.tsx
+++ b/frontend/src/pages/Category/Category.tsx
@@ -65,7 +65,7 @@ export default function CategoryPage() {
   const [categoryItems, setCategoryItems] = useState<CategoryFilterItem[]>([]);
   const [currentCategory, setCurrentCategory] = useState<Category | null>(null);
   const [productPage, setProductPage] = useState<ProductPage>(EMPTY_PAGE);
-  const [isLoading, setIsLoading] = useState(true);
+  const [resolvedRequestKey, setResolvedRequestKey] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [categoryNotFound, setCategoryNotFound] = useState(false);
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
@@ -76,12 +76,13 @@ export default function CategoryPage() {
   const currentPage = readPage(searchParams.get("page"));
   const currentSort = readSort(searchParams.get("sort"));
   const searchTerm = searchParams.get("search")?.trim() ?? "";
+  const requestKey = `${location.pathname}?${searchParams.toString()}#${reloadKey}`;
+  const isLoading = resolvedRequestKey !== requestKey;
 
   useEffect(() => {
     let cancelled = false;
 
     const loadCatalog = async () => {
-      setIsLoading(true);
       setError(null);
       setCategoryNotFound(false);
 
@@ -139,7 +140,7 @@ export default function CategoryPage() {
         if (loadError instanceof CategoryNotFoundError) setCategoryNotFound(true);
         else setError(loadError instanceof Error ? loadError.message : "Unable to load the catalog.");
       } finally {
-        if (!cancelled) setIsLoading(false);
+        if (!cancelled) setResolvedRequestKey(requestKey);
       }
     };
 
@@ -148,7 +149,7 @@ export default function CategoryPage() {
     return () => {
       cancelled = true;
     };
-  }, [currentPage, currentSort, reloadKey, searchTerm, segments]);
+  }, [currentPage, currentSort, requestKey, searchTerm, segments]);
 
   const updatePage = (page: number) => {
     const nextParams = new URLSearchParams(searchParams);
@@ -165,17 +166,23 @@ export default function CategoryPage() {
     setSearchParams(nextParams);
   };
 
-  if (categoryNotFound) return <NotFoundPage />;
+  if (!isLoading && categoryNotFound) return <NotFoundPage />;
 
-  const title = searchTerm ? `Search results for “${searchTerm}”` : (currentCategory?.name ?? "All products");
+  const title = searchTerm
+    ? `Search results for “${searchTerm}”`
+    : isLoading
+      ? "Catalog"
+      : (currentCategory?.name ?? "All products");
+  const visibleBreadcrumbs = isLoading ? [] : breadcrumbs;
+  const visibleCategoryItems = isLoading ? [] : categoryItems;
 
   return (
     <PageContainer className="category-page">
-      <Breadcrumbs crumbs={breadcrumbs} />
+      <Breadcrumbs crumbs={visibleBreadcrumbs} />
 
       <div className="category-page__layout">
         <aside className="category-page__sidebar">
-          <CategoryFilter items={categoryItems} />
+          <CategoryFilter items={visibleCategoryItems} />
         </aside>
 
         <main aria-labelledby="catalog-title" className="category-page__main">
@@ -199,7 +206,7 @@ export default function CategoryPage() {
           </header>
 
           {isLoading ? (
-            <div aria-live="polite" className="category-page__status" role="status">
+            <div aria-label="Catalog loading" aria-live="polite" className="category-page__status" role="status">
               <span className="category-page__spinner" />
               Loading products…
             </div>
@@ -232,7 +239,7 @@ export default function CategoryPage() {
       <div id="catalog-options">
         <FilterDrawer isOpen={isDrawerOpen} onClose={() => setIsDrawerOpen(false)}>
           <Sorting currentSort={currentSort} onSortChange={updateSort} />
-          <CategoryFilter items={categoryItems} onNavigate={() => setIsDrawerOpen(false)} />
+          <CategoryFilter items={visibleCategoryItems} onNavigate={() => setIsDrawerOpen(false)} />
         </FilterDrawer>
       </div>
     </PageContainer>

--- a/frontend/src/pages/Product/Product.spec.tsx
+++ b/frontend/src/pages/Product/Product.spec.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { Link, MemoryRouter, Route, Routes } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { fetchCategoryTrail } from "../../services/categoryService/categoryService";
@@ -33,11 +33,26 @@ const product: Product = {
   oldPrice: 4499,
 };
 
+const secondProduct: Product = {
+  ...product,
+  id: "product-two",
+  slug: "training-backpack",
+  name: "Training Backpack",
+};
+
 function renderProduct() {
   render(
     <MemoryRouter initialEntries={["/product/product-id"]}>
       <Routes>
-        <Route element={<ProductPage />} path="/product/:id" />
+        <Route
+          element={
+            <>
+              <ProductPage />
+              <Link to="/product/product-two">Open product two</Link>
+            </>
+          }
+          path="/product/:id"
+        />
       </Routes>
     </MemoryRouter>
   );
@@ -68,6 +83,25 @@ describe("ProductPage", () => {
     expect(screen.getByRole("navigation", { name: "Breadcrumb" })).toHaveTextContent(
       "HomeCatalogBallsFootballMatch Football"
     );
+  });
+
+  it("hides the previous product while a new URL is loading", async () => {
+    let resolveSecondProduct!: (product: Product | null) => void;
+    const secondProductRequest = new Promise<Product | null>((resolve) => {
+      resolveSecondProduct = resolve;
+    });
+    vi.mocked(fetchProductById).mockResolvedValueOnce(product).mockReturnValueOnce(secondProductRequest);
+
+    renderProduct();
+    expect(await screen.findByRole("heading", { name: "Match Football" })).toBeVisible();
+
+    fireEvent.click(screen.getByRole("link", { name: "Open product two" }));
+
+    expect(screen.getByRole("status", { name: "Product loading" })).toBeVisible();
+    expect(screen.queryByRole("heading", { name: "Match Football" })).not.toBeInTheDocument();
+
+    resolveSecondProduct(secondProduct);
+    expect(await screen.findByRole("heading", { name: "Training Backpack" })).toBeVisible();
   });
 
   it("shows the not-found page for an unknown product", async () => {

--- a/frontend/src/pages/Product/Product.tsx
+++ b/frontend/src/pages/Product/Product.tsx
@@ -27,10 +27,13 @@ export default function ProductPage() {
   const [product, setProduct] = useState<Product | null>(null);
   const [categoryTrail, setCategoryTrail] = useState<Category[]>([]);
   const [recommendations, setRecommendations] = useState<Product[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
+  const [resolvedRequestKey, setResolvedRequestKey] = useState<string | null>(null);
   const [notFound, setNotFound] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [reloadKey, setReloadKey] = useState(0);
+  const requestKey = `${id ?? "missing"}#${reloadKey}`;
+  const isLoading = resolvedRequestKey !== requestKey;
+  const visibleProduct = product?.id === id && !isLoading ? product : null;
 
   useEffect(() => {
     let cancelled = false;
@@ -39,13 +42,12 @@ export default function ProductPage() {
       setProduct(null);
       setCategoryTrail([]);
       setRecommendations([]);
-      setIsLoading(true);
       setNotFound(false);
       setError(null);
 
       if (!id) {
         setNotFound(true);
-        setIsLoading(false);
+        setResolvedRequestKey(requestKey);
         return;
       }
 
@@ -55,7 +57,7 @@ export default function ProductPage() {
       } catch (loadError) {
         if (!cancelled) {
           setError(loadError instanceof Error ? loadError.message : "Unable to load this product.");
-          setIsLoading(false);
+          setResolvedRequestKey(requestKey);
         }
         return;
       }
@@ -63,12 +65,12 @@ export default function ProductPage() {
       if (cancelled) return;
       if (!nextProduct) {
         setNotFound(true);
-        setIsLoading(false);
+        setResolvedRequestKey(requestKey);
         return;
       }
 
       setProduct(nextProduct);
-      setIsLoading(false);
+      setResolvedRequestKey(requestKey);
 
       const categoryId = nextProduct.categoryIds[0];
       if (!categoryId) return;
@@ -90,19 +92,19 @@ export default function ProductPage() {
     return () => {
       cancelled = true;
     };
-  }, [id, reloadKey]);
+  }, [id, requestKey]);
 
   const breadcrumbs = useMemo<Crumb[]>(() => {
     if (!product) return [];
     return [...categoryCrumbs(categoryTrail), { name: product.name, path: `/product/${product.id}` }];
   }, [categoryTrail, product]);
 
-  if (notFound) return <NotFoundPage />;
+  if (!isLoading && notFound) return <NotFoundPage />;
 
   return (
     <PageContainer className="product-page">
       {isLoading ? (
-        <div aria-live="polite" className="product-page__status" role="status">
+        <div aria-label="Product loading" aria-live="polite" className="product-page__status" role="status">
           <span className="product-page__spinner" />
           Loading product…
         </div>
@@ -113,15 +115,15 @@ export default function ProductPage() {
             Try again
           </button>
         </div>
-      ) : product ? (
+      ) : visibleProduct ? (
         <>
           <Breadcrumbs crumbs={breadcrumbs} />
           <main className="product-page__main">
             <div className="product-page__hero">
-              <ProductGallery images={product.imgUrls} productName={product.name} />
-              <ProductPurchasePanel product={product} />
+              <ProductGallery images={visibleProduct.imgUrls} productName={visibleProduct.name} />
+              <ProductPurchasePanel product={visibleProduct} />
             </div>
-            <RelatedProducts currentProductId={product.id} products={recommendations} />
+            <RelatedProducts currentProductId={visibleProduct.id} products={recommendations} />
           </main>
         </>
       ) : null}


### PR DESCRIPTION
## Summary

- synchronize Catalog loading state with the current pathname, query parameters, and retry attempt
- hide breadcrumbs, filters, products, and not-found state that belong to a previous Catalog request
- render Product content only when the loaded product and completed request match the current route ID
- add deterministic unit tests with deferred requests and a browser-level slow API scenario

## Root cause

Catalog and Product fetch their data in `useEffect`. When React Router reused either page for a new URL, the first render could still contain state from the previous request because effects run after render. This was difficult to notice against the local API but could expose stale content for a frame on a slower network or device.

## User impact

Navigation now switches directly to the correct loading state. A new Catalog URL cannot display the previous product list, category navigation, breadcrumbs, or 404 state, and a new Product URL cannot display the previous product.

## Validation

- frontend: 69 test files, 149 tests passed
- backend: 8 test files, 19 tests passed
- ESLint passed
- Prettier check passed
- frontend and backend production builds passed
- all 4 Playwright smoke scenarios passed, including explicitly blocked Catalog and Product API requests
