### PR TITLE
feat(frontend): add i18n foundation and language switcher

### DIFF
--- a/e2e/store.spec.ts
+++ b/e2e/store.spec.ts
@@ -1,5 +1,28 @@
 import { expect, test } from "@playwright/test";
 
+test("switches and persists the interface language", async ({ page }) => {
+  await page.goto("/");
+
+  await page.getByRole("button", { name: "Current language: English" }).click();
+  await page.getByRole("menuitemradio", { name: "DE Deutsch" }).click();
+
+  await expect(page.locator("html")).toHaveAttribute("lang", "de");
+  await expect(page).toHaveTitle("Sport Gear | Sportausrüstung");
+  await expect(page.getByRole("button", { name: "Aktuelle Sprache: Deutsch" })).toContainText("DE");
+
+  await page.reload();
+
+  await expect(page.locator("html")).toHaveAttribute("lang", "de");
+  await expect(page.getByRole("button", { name: "Aktuelle Sprache: Deutsch" })).toContainText("DE");
+
+  await page.getByRole("button", { name: "Aktuelle Sprache: Deutsch" }).click();
+  await page.getByRole("menuitemradio", { name: "RU Русский" }).click();
+
+  await expect(page.locator("html")).toHaveAttribute("lang", "ru");
+  await expect(page).toHaveTitle("Sport Gear | Спортивные товары");
+  await expect(page.getByRole("button", { name: "Текущий язык: Русский" })).toContainText("RU");
+});
+
 test("registers, shops with a promo code, opens profile and logs out", async ({ page }) => {
   const email = `playwright-${Date.now()}@example.com`;
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Sport goods</title>
+    <title>Sport Gear</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,8 +17,10 @@
   "dependencies": {
     "@fontsource/roboto": "^5.3.0",
     "axios": "^1.18.1",
+    "i18next": "^26.3.6",
     "react": "19.1.0",
     "react-dom": "19.1.0",
+    "react-i18next": "^17.0.11",
     "react-icons": "5.5.0",
     "react-router-dom": "^7.18.1",
     "swiper": "^14.0.5"

--- a/frontend/src/components/Header/Header.scss
+++ b/frontend/src/components/Header/Header.scss
@@ -26,7 +26,8 @@
 .site-header__menu-toggle,
 .site-header__search-toggle,
 .site-header__mobile-search,
-.site-header__mobile-menu {
+.site-header__mobile-menu,
+.site-header__mobile-language {
   display: none;
 }
 
@@ -46,7 +47,8 @@
   }
 
   .site-header__desktop-navigation,
-  .site-header__desktop-search {
+  .site-header__desktop-search,
+  .site-header__desktop-language {
     display: none;
   }
 
@@ -73,5 +75,20 @@
 
   .site-header__mobile-menu-inner {
     padding-block: var(--space-3);
+  }
+
+  .site-header__mobile-language {
+    display: flex;
+    padding-top: var(--space-4);
+    margin-top: var(--space-4);
+    align-items: center;
+    justify-content: space-between;
+    border-top: var(--border-subtle);
+  }
+
+  .site-header__mobile-language-label {
+    color: var(--color-text-muted);
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-medium);
   }
 }

--- a/frontend/src/components/Header/Header.spec.tsx
+++ b/frontend/src/components/Header/Header.spec.tsx
@@ -51,6 +51,7 @@ describe("Header", () => {
     expect(screen.getByRole("link", { name: "Sport Gear home" })).toBeInTheDocument();
     expect(screen.getByRole("navigation", { name: "Primary navigation" })).toBeInTheDocument();
     expect(screen.getByRole("search", { name: "Product search" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Current language: English" })).toHaveTextContent("EN");
     expect(screen.getByRole("link", { name: "Shopping cart, empty" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Sign in" })).toBeInTheDocument();
   });
@@ -63,6 +64,7 @@ describe("Header", () => {
     expect(screen.getByRole("button", { name: "Close menu" })).toHaveAttribute("aria-expanded", "true");
     expect(document.body).toHaveClass("no-scroll");
     expect(screen.getAllByRole("navigation", { name: "Primary navigation" })).toHaveLength(2);
+    expect(screen.getByText("Language")).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Open search" }));
 

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useState } from "react";
 import { IoCloseOutline, IoMenuOutline, IoSearchOutline } from "react-icons/io5";
+import { useTranslation } from "react-i18next";
 import { useLocation } from "react-router-dom";
 
 import { IconButton } from "../common/IconButton/IconButton";
+import { LanguageSwitcher } from "../common/LanguageSwitcher/LanguageSwitcher";
 import { PageContainer } from "../common/PageContainer/PageContainer";
 import { StoreLogo } from "../common/StoreLogo/StoreLogo";
 import { HeaderActions } from "./HeaderActions/HeaderActions";
@@ -12,6 +14,7 @@ import { HeaderSearch } from "./HeaderSearch/HeaderSearch";
 import "./Header.scss";
 
 function Header() {
+  const { t } = useTranslation("common");
   const location = useLocation();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isSearchOpen, setIsSearchOpen] = useState(false);
@@ -51,6 +54,7 @@ function Header() {
         <StoreLogo className="site-header__logo" />
         <HeaderNavigation className="site-header__desktop-navigation" />
         <HeaderSearch className="site-header__desktop-search" />
+        <LanguageSwitcher className="site-header__desktop-language" />
         <IconButton
           aria-controls="mobile-search"
           aria-expanded={isSearchOpen}
@@ -72,6 +76,10 @@ function Header() {
         <div className="site-header__mobile-menu" id="mobile-navigation">
           <PageContainer className="site-header__mobile-menu-inner">
             <HeaderNavigation onNavigate={() => setIsMenuOpen(false)} orientation="vertical" />
+            <div className="site-header__mobile-language">
+              <span className="site-header__mobile-language-label">{t("language.label")}</span>
+              <LanguageSwitcher />
+            </div>
           </PageContainer>
         </div>
       )}

--- a/frontend/src/components/common/LanguageSwitcher/LanguageSwitcher.scss
+++ b/frontend/src/components/common/LanguageSwitcher/LanguageSwitcher.scss
@@ -1,0 +1,114 @@
+.language-switcher {
+  position: relative;
+  flex: 0 0 auto;
+}
+
+.language-switcher__trigger {
+  display: inline-flex;
+  min-width: 8.4rem;
+  height: 4rem;
+  padding-inline: var(--space-3);
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  border: var(--border-subtle);
+  border-radius: var(--radius-pill);
+  background-color: var(--color-surface);
+  color: var(--color-ink);
+  cursor: pointer;
+  transition:
+    background-color var(--transition-fast),
+    transform var(--transition-fast);
+
+  &:hover,
+  &[aria-expanded="true"] {
+    background-color: var(--color-surface-subtle);
+  }
+
+  &:active {
+    transform: scale(0.97);
+  }
+}
+
+.language-switcher__translate-icon {
+  width: 2rem;
+  height: 2rem;
+}
+
+.language-switcher__code {
+  min-width: 2ch;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  letter-spacing: 0.04em;
+}
+
+.language-switcher__caret {
+  width: 1.4rem;
+  height: 1.4rem;
+  transition: transform var(--transition-fast);
+
+  [aria-expanded="true"] & {
+    transform: rotate(180deg);
+  }
+}
+
+.language-switcher__menu {
+  position: absolute;
+  z-index: 20;
+  top: calc(100% + var(--space-2));
+  display: grid;
+  width: 19.2rem;
+  padding: var(--space-2);
+  border: var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background-color: var(--color-surface);
+  box-shadow: 0 1.2rem 3.2rem rgb(0 0 0 / 14%);
+}
+
+.language-switcher--right .language-switcher__menu {
+  right: 0;
+}
+
+.language-switcher--left .language-switcher__menu {
+  left: 0;
+}
+
+.language-switcher__option {
+  display: grid;
+  min-height: 4.4rem;
+  padding: var(--space-2) var(--space-3);
+  grid-template-columns: 3.2rem 1fr 2rem;
+  align-items: center;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--color-ink);
+  cursor: pointer;
+  text-align: left;
+
+  &:hover,
+  &:focus-visible {
+    background-color: var(--color-surface-subtle);
+  }
+}
+
+.language-switcher__option-code {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  letter-spacing: 0.04em;
+}
+
+.language-switcher__option-label {
+  font-size: var(--font-size-sm);
+}
+
+.language-switcher__check {
+  width: 1.8rem;
+  height: 1.8rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .language-switcher__caret {
+    transition: none;
+  }
+}

--- a/frontend/src/components/common/LanguageSwitcher/LanguageSwitcher.spec.tsx
+++ b/frontend/src/components/common/LanguageSwitcher/LanguageSwitcher.spec.tsx
@@ -1,0 +1,49 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+
+import i18n, { i18nInitialization } from "../../../i18n/i18n";
+import { LanguageSwitcher } from "./LanguageSwitcher";
+
+describe("LanguageSwitcher", () => {
+  beforeAll(async () => {
+    await i18nInitialization;
+  });
+
+  afterEach(async () => {
+    await i18n.changeLanguage("en");
+  });
+
+  it("shows two-letter codes and changes the active language", async () => {
+    render(<LanguageSwitcher />);
+
+    const trigger = screen.getByRole("button", { name: "Current language: English" });
+    expect(trigger).toHaveTextContent("EN");
+
+    fireEvent.click(trigger);
+    expect(screen.getByRole("menu", { name: "Available languages" })).toBeVisible();
+    expect(screen.getByRole("menuitemradio", { name: "DE Deutsch" })).toHaveAttribute("aria-checked", "false");
+
+    fireEvent.click(screen.getByRole("menuitemradio", { name: "DE Deutsch" }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Aktuelle Sprache: Deutsch" })).toHaveTextContent("DE")
+    );
+  });
+
+  it("supports keyboard opening, navigation, and closing", async () => {
+    render(<LanguageSwitcher />);
+    const trigger = screen.getByRole("button", { name: "Current language: English" });
+
+    fireEvent.keyDown(trigger, { key: "ArrowDown" });
+    const englishOption = screen.getByRole("menuitemradio", { name: "EN English" });
+    const germanOption = screen.getByRole("menuitemradio", { name: "DE Deutsch" });
+
+    await waitFor(() => expect(englishOption).toHaveFocus());
+    fireEvent.keyDown(englishOption, { key: "ArrowDown" });
+    expect(germanOption).toHaveFocus();
+
+    fireEvent.keyDown(germanOption, { key: "Escape" });
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    await waitFor(() => expect(trigger).toHaveFocus());
+  });
+});

--- a/frontend/src/components/common/LanguageSwitcher/LanguageSwitcher.tsx
+++ b/frontend/src/components/common/LanguageSwitcher/LanguageSwitcher.tsx
@@ -1,0 +1,144 @@
+import { useEffect, useId, useRef, useState, type ComponentPropsWithoutRef, type KeyboardEvent } from "react";
+import { PiCaretDown, PiCheck, PiTranslate } from "react-icons/pi";
+import { useTranslation } from "react-i18next";
+
+import { LANGUAGE_OPTIONS, normalizeLanguage, type SupportedLanguage } from "../../../i18n/languages";
+
+import "./LanguageSwitcher.scss";
+
+type LanguageSwitcherProps = Omit<ComponentPropsWithoutRef<"div">, "children"> & {
+  align?: "left" | "right";
+};
+
+export function LanguageSwitcher({ align = "right", className = "", ...props }: LanguageSwitcherProps) {
+  const { i18n, t } = useTranslation("common");
+  const [isOpen, setIsOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const optionRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const menuId = useId();
+  const currentLanguage = normalizeLanguage(i18n.resolvedLanguage) ?? "en";
+  const currentOption = LANGUAGE_OPTIONS.find(({ code }) => code === currentLanguage) ?? LANGUAGE_OPTIONS[0];
+  const classes = `language-switcher language-switcher--${align} ${className}`.trim();
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const closeOnOutsidePointer = (event: PointerEvent) => {
+      if (!rootRef.current?.contains(event.target as Node)) setIsOpen(false);
+    };
+
+    document.addEventListener("pointerdown", closeOnOutsidePointer);
+    return () => document.removeEventListener("pointerdown", closeOnOutsidePointer);
+  }, [isOpen]);
+
+  const closeMenu = (restoreFocus = false) => {
+    setIsOpen(false);
+    if (restoreFocus) requestAnimationFrame(() => triggerRef.current?.focus());
+  };
+
+  const focusOption = (index: number) => {
+    const optionCount = LANGUAGE_OPTIONS.length;
+    optionRefs.current[(index + optionCount) % optionCount]?.focus();
+  };
+
+  const openMenu = (focus: "current" | "first" | "last" = "current") => {
+    setIsOpen(true);
+    requestAnimationFrame(() => {
+      if (focus === "first") focusOption(0);
+      else if (focus === "last") focusOption(LANGUAGE_OPTIONS.length - 1);
+      else focusOption(LANGUAGE_OPTIONS.findIndex(({ code }) => code === currentLanguage));
+    });
+  };
+
+  const handleTriggerKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      openMenu("first");
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      openMenu("last");
+    }
+  };
+
+  const handleMenuKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    const currentIndex = optionRefs.current.findIndex((option) => option === document.activeElement);
+
+    if (event.key === "Escape") {
+      event.preventDefault();
+      closeMenu(true);
+    } else if (event.key === "ArrowDown") {
+      event.preventDefault();
+      focusOption(currentIndex + 1);
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      focusOption(currentIndex - 1);
+    } else if (event.key === "Home") {
+      event.preventDefault();
+      focusOption(0);
+    } else if (event.key === "End") {
+      event.preventDefault();
+      focusOption(LANGUAGE_OPTIONS.length - 1);
+    } else if (event.key === "Tab") {
+      setIsOpen(false);
+    }
+  };
+
+  const selectLanguage = async (language: SupportedLanguage) => {
+    await i18n.changeLanguage(language);
+    closeMenu(true);
+  };
+
+  return (
+    <div {...props} className={classes} ref={rootRef}>
+      <button
+        aria-controls={menuId}
+        aria-expanded={isOpen}
+        aria-haspopup="menu"
+        aria-label={t("language.selected", { language: currentOption.label })}
+        className="language-switcher__trigger"
+        onClick={() => (isOpen ? closeMenu() : openMenu())}
+        onKeyDown={handleTriggerKeyDown}
+        ref={triggerRef}
+        title={t("language.change")}
+        type="button"
+      >
+        <PiTranslate aria-hidden="true" className="language-switcher__translate-icon" />
+        <span className="language-switcher__code">{currentOption.code.toUpperCase()}</span>
+        <PiCaretDown aria-hidden="true" className="language-switcher__caret" />
+      </button>
+
+      {isOpen && (
+        <div
+          aria-label={t("language.menu")}
+          className="language-switcher__menu"
+          id={menuId}
+          onKeyDown={handleMenuKeyDown}
+          role="menu"
+        >
+          {LANGUAGE_OPTIONS.map((option, index) => {
+            const isSelected = option.code === currentLanguage;
+
+            return (
+              <button
+                aria-checked={isSelected}
+                className="language-switcher__option"
+                key={option.code}
+                onClick={() => void selectLanguage(option.code)}
+                ref={(element) => {
+                  optionRefs.current[index] = element;
+                }}
+                role="menuitemradio"
+                type="button"
+              >
+                <span className="language-switcher__option-code">{option.code.toUpperCase()}</span>
+                <span className="language-switcher__option-label">{option.label}</span>
+                {isSelected && <PiCheck aria-hidden="true" className="language-switcher__check" />}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/i18n/i18n.spec.ts
+++ b/frontend/src/i18n/i18n.spec.ts
@@ -1,0 +1,19 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import i18n, { i18nInitialization } from "./i18n";
+import { LANGUAGE_STORAGE_KEY } from "./languages";
+
+describe("i18n", () => {
+  afterEach(async () => {
+    await i18n.changeLanguage("en");
+  });
+
+  it("persists language changes and synchronizes document metadata", async () => {
+    await i18nInitialization;
+    await i18n.changeLanguage("de");
+
+    expect(localStorage.getItem(LANGUAGE_STORAGE_KEY)).toBe("de");
+    expect(document.documentElement.lang).toBe("de");
+    expect(document.title).toBe("Sport Gear | Sportausrüstung");
+  });
+});

--- a/frontend/src/i18n/i18n.ts
+++ b/frontend/src/i18n/i18n.ts
@@ -1,0 +1,46 @@
+import i18n from "i18next";
+import { initReactI18next } from "react-i18next";
+
+import { deCommon } from "./locales/de/common";
+import { enCommon } from "./locales/en/common";
+import { ruCommon } from "./locales/ru/common";
+import {
+  DEFAULT_LANGUAGE,
+  detectLanguage,
+  LANGUAGE_STORAGE_KEY,
+  normalizeLanguage,
+  SUPPORTED_LANGUAGES,
+} from "./languages";
+
+const browserLanguages = typeof navigator === "undefined" ? [] : navigator.languages;
+const storedLanguage = typeof localStorage === "undefined" ? null : localStorage.getItem(LANGUAGE_STORAGE_KEY);
+const initialLanguage = detectLanguage(storedLanguage, browserLanguages);
+
+export const i18nInitialization = i18n.use(initReactI18next).init({
+  resources: {
+    en: { common: enCommon },
+    de: { common: deCommon },
+    ru: { common: ruCommon },
+  },
+  lng: initialLanguage,
+  fallbackLng: DEFAULT_LANGUAGE,
+  supportedLngs: SUPPORTED_LANGUAGES,
+  defaultNS: "common",
+  interpolation: { escapeValue: false },
+  returnNull: false,
+});
+
+function synchronizeDocument(language: string) {
+  const supportedLanguage = normalizeLanguage(language) ?? DEFAULT_LANGUAGE;
+
+  if (typeof localStorage !== "undefined") localStorage.setItem(LANGUAGE_STORAGE_KEY, supportedLanguage);
+  if (typeof document !== "undefined") {
+    document.documentElement.lang = supportedLanguage;
+    document.title = i18n.t("meta.title", { lng: supportedLanguage });
+  }
+}
+
+i18n.on("languageChanged", synchronizeDocument);
+void i18nInitialization.then(() => synchronizeDocument(i18n.resolvedLanguage ?? initialLanguage));
+
+export default i18n;

--- a/frontend/src/i18n/i18next.d.ts
+++ b/frontend/src/i18n/i18next.d.ts
@@ -1,0 +1,12 @@
+import "i18next";
+import type { enCommon } from "./locales/en/common";
+
+declare module "i18next" {
+  interface CustomTypeOptions {
+    defaultNS: "common";
+    returnNull: false;
+    resources: {
+      common: typeof enCommon;
+    };
+  }
+}

--- a/frontend/src/i18n/languages.spec.ts
+++ b/frontend/src/i18n/languages.spec.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { detectLanguage, normalizeLanguage } from "./languages";
+
+describe("language detection", () => {
+  it("normalizes supported regional language tags", () => {
+    expect(normalizeLanguage("de-DE")).toBe("de");
+    expect(normalizeLanguage("RU-ru")).toBe("ru");
+    expect(normalizeLanguage("fr-FR")).toBeNull();
+  });
+
+  it("prefers a stored language over browser preferences", () => {
+    expect(detectLanguage("ru", ["de-DE", "en-US"])).toBe("ru");
+  });
+
+  it("uses a supported browser language and falls back to English", () => {
+    expect(detectLanguage(null, ["fr-FR", "de-DE"])).toBe("de");
+    expect(detectLanguage("fr", ["es-ES"])).toBe("en");
+  });
+});

--- a/frontend/src/i18n/languages.ts
+++ b/frontend/src/i18n/languages.ts
@@ -1,0 +1,30 @@
+export const SUPPORTED_LANGUAGES = ["en", "de", "ru"] as const;
+
+export type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number];
+
+export const DEFAULT_LANGUAGE: SupportedLanguage = "en";
+export const LANGUAGE_STORAGE_KEY = "sport-gear-language";
+
+export const LANGUAGE_OPTIONS: ReadonlyArray<{ code: SupportedLanguage; label: string }> = [
+  { code: "en", label: "English" },
+  { code: "de", label: "Deutsch" },
+  { code: "ru", label: "Русский" },
+];
+
+export function normalizeLanguage(value: string | null | undefined): SupportedLanguage | null {
+  if (!value) return null;
+  const language = value.toLowerCase().split("-")[0];
+  return SUPPORTED_LANGUAGES.find((supportedLanguage) => supportedLanguage === language) ?? null;
+}
+
+export function detectLanguage(storedLanguage: string | null, browserLanguages: readonly string[]): SupportedLanguage {
+  const savedLanguage = normalizeLanguage(storedLanguage);
+  if (savedLanguage) return savedLanguage;
+
+  for (const browserLanguage of browserLanguages) {
+    const supportedLanguage = normalizeLanguage(browserLanguage);
+    if (supportedLanguage) return supportedLanguage;
+  }
+
+  return DEFAULT_LANGUAGE;
+}

--- a/frontend/src/i18n/locales/de/common.ts
+++ b/frontend/src/i18n/locales/de/common.ts
@@ -1,0 +1,12 @@
+import type { CommonTranslations } from "../en/common";
+
+export const deCommon = {
+  meta: {
+    title: "Sport Gear | Sportausrüstung",
+  },
+  language: {
+    change: "Sprache ändern",
+    menu: "Verfügbare Sprachen",
+    selected: "Aktuelle Sprache: {{language}}",
+  },
+} satisfies CommonTranslations;

--- a/frontend/src/i18n/locales/de/common.ts
+++ b/frontend/src/i18n/locales/de/common.ts
@@ -5,6 +5,7 @@ export const deCommon = {
     title: "Sport Gear | Sportausrüstung",
   },
   language: {
+    label: "Sprache",
     change: "Sprache ändern",
     menu: "Verfügbare Sprachen",
     selected: "Aktuelle Sprache: {{language}}",

--- a/frontend/src/i18n/locales/en/common.ts
+++ b/frontend/src/i18n/locales/en/common.ts
@@ -3,6 +3,7 @@ export const enCommon = {
     title: "Sport Gear | Sports equipment",
   },
   language: {
+    label: "Language",
     change: "Change language",
     menu: "Available languages",
     selected: "Current language: {{language}}",

--- a/frontend/src/i18n/locales/en/common.ts
+++ b/frontend/src/i18n/locales/en/common.ts
@@ -1,0 +1,16 @@
+export const enCommon = {
+  meta: {
+    title: "Sport Gear | Sports equipment",
+  },
+  language: {
+    change: "Change language",
+    menu: "Available languages",
+    selected: "Current language: {{language}}",
+  },
+} as const;
+
+export type CommonTranslations = {
+  [Key in keyof typeof enCommon]: {
+    [NestedKey in keyof (typeof enCommon)[Key]]: string;
+  };
+};

--- a/frontend/src/i18n/locales/ru/common.ts
+++ b/frontend/src/i18n/locales/ru/common.ts
@@ -1,0 +1,12 @@
+import type { CommonTranslations } from "../en/common";
+
+export const ruCommon = {
+  meta: {
+    title: "Sport Gear | Спортивные товары",
+  },
+  language: {
+    change: "Изменить язык",
+    menu: "Доступные языки",
+    selected: "Текущий язык: {{language}}",
+  },
+} satisfies CommonTranslations;

--- a/frontend/src/i18n/locales/ru/common.ts
+++ b/frontend/src/i18n/locales/ru/common.ts
@@ -5,6 +5,7 @@ export const ruCommon = {
     title: "Sport Gear | Спортивные товары",
   },
   language: {
+    label: "Язык",
     change: "Изменить язык",
     menu: "Доступные языки",
     selected: "Текущий язык: {{language}}",

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,14 +1,17 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
+import { i18nInitialization } from "./i18n/i18n.ts";
 
 import "@fontsource/roboto/latin-400.css";
 import "@fontsource/roboto/latin-500.css";
 import "@fontsource/roboto/latin-700.css";
 import "./assets/styles/global.scss";
 
-createRoot(document.getElementById("root")!).render(
-  <StrictMode>
-    <App />
-  </StrictMode>
-);
+void i18nInitialization.then(() => {
+  createRoot(document.getElementById("root")!).render(
+    <StrictMode>
+      <App />
+    </StrictMode>
+  );
+});

--- a/frontend/src/tests/setup.ts
+++ b/frontend/src/tests/setup.ts
@@ -1,1 +1,8 @@
 import "@testing-library/jest-dom";
+import { beforeAll } from "vitest";
+
+import { i18nInitialization } from "../i18n/i18n";
+
+beforeAll(async () => {
+  await i18nInitialization;
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -470,8 +470,10 @@
       "dependencies": {
         "@fontsource/roboto": "^5.3.0",
         "axios": "^1.18.1",
+        "i18next": "^26.3.6",
         "react": "19.1.0",
         "react-dom": "19.1.0",
+        "react-i18next": "^17.0.11",
         "react-icons": "5.5.0",
         "react-router-dom": "^7.18.1",
         "swiper": "^14.0.5"
@@ -1003,10 +1005,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.27.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
-      "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
-      "dev": true,
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -8156,6 +8157,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/html-parse-stringify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-4.0.1.tgz",
+      "integrity": "sha512-0zHsZJrK7S3K2aucXWL6ycoYJ/iNtIcFHC/nYQgFklPtrv5LpJctIiSCroWZWeuoXvuyFdzp6KzjJQ+OT5MfFw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://locize.com"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -8225,6 +8235,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "26.3.6",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.3.6.tgz",
+      "integrity": "sha512-Bu5Z2nAXgfVyM8xvW3jk9EKRIuX37PudsrBViThNFx7CR7aaYTpP01cxNB/E4c4UUzTDiAZRstEhsRfPOL/8xA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://www.locize.com/i18next"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.locize.com"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": "^5 || ^6 || ^7"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/iconv-lite": {
@@ -10602,6 +10640,33 @@
         "react": "^19.1.0"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "17.0.11",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-17.0.11.tgz",
+      "integrity": "sha512-cDtkXgxjuFTWUH6V+aQn1Ve5vDiUztCNPWW5GtSHDccsgRXO1nE6QFWCEmc1KAutrb3OUv87wFShJL5RhUwPXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "html-parse-stringify": "^4.0.1",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "i18next": ">= 26.2.0",
+        "react": ">= 16.8.0",
+        "typescript": "^5 || ^6 || ^7"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-icons": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
@@ -12710,6 +12775,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {


### PR DESCRIPTION
## Summary

Introduces the frontend internationalization foundation for English, German, and Russian and adds an accessible language selector to the responsive store header.

## What changed

- added `i18next` and `react-i18next` with typed translation resources
- configured English, German, and Russian as the supported languages
- detect the initial language from the saved preference or browser locale
- persist the selected language and synchronize the document `lang` attribute and page title
- wait for i18n initialization before rendering React to avoid translation-key flashes
- added a reusable two-letter `EN / DE / RU` dropdown with a translation icon
- supported mouse, outside-click, and full keyboard navigation
- integrated the selector into the desktop header and mobile navigation menu
- added unit, integration, and Playwright persistence coverage

## UX and accessibility

- the active language is marked with a check icon
- the dropdown exposes menu and radio-item semantics to assistive technology
- Arrow Up/Down, Home, End, Escape, and focus restoration are supported
- the mobile dropdown opens inward and stays within narrow viewports
- reduced-motion preferences are respected

## Scope

This PR establishes the i18n infrastructure and language-selection UI. Storefront pages still use their existing English copy and can now be migrated domain by domain in follow-up PRs.
