### PR TITLE
feat(frontend): localize the home page

### DIFF
--- a/e2e/store.spec.ts
+++ b/e2e/store.spec.ts
@@ -16,6 +16,14 @@ test("switches and persists the interface language", async ({ page }) => {
   await expect(page.getByRole("search", { name: "Produktsuche" })).toBeVisible();
   await expect(page.getByRole("navigation", { name: "Unternehmen" })).toBeVisible();
   await expect(page.getByRole("heading", { name: "VERPASSE KEINE UNSERER NEUESTEN ANGEBOTE" })).toBeVisible();
+  await expect(
+    page.getByRole("heading", { level: 1, name: "FINDE AUSRÜSTUNG, DIE ZU DEINEN ZIELEN PASST" })
+  ).toBeVisible();
+  await expect(page.getByRole("link", { name: "Jetzt shoppen" })).toHaveAttribute("href", "/catalog");
+  await expect(page.getByRole("group", { name: "Sportarten bei Sport Gear" })).toContainText("Regenerieren");
+  await expect(page.getByRole("region", { name: "Neu eingetroffen" })).toBeVisible();
+  await expect(page.getByRole("region", { name: "NACH SPORTART ENTDECKEN" })).toContainText("Krafttraining");
+  await expect(page.getByRole("region", { name: "WARUM SPORT GEAR" })).toContainText("Preise direkt vom Server");
 
   await page.reload();
 
@@ -36,6 +44,11 @@ test("switches and persists the interface language", async ({ page }) => {
   );
   await expect(page.getByRole("navigation", { name: "Компания" })).toBeVisible();
   await expect(page.getByText("Демонстрационный магазин · Платежи не проводятся")).toBeVisible();
+  await expect(page.getByRole("heading", { level: 1, name: "НАЙДИ ЭКИПИРОВКУ ДЛЯ СВОИХ ЦЕЛЕЙ" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Перейти в магазин" })).toHaveAttribute("href", "/catalog");
+  await expect(page.getByRole("region", { name: "Новинки" })).toBeVisible();
+  await expect(page.getByRole("region", { name: "ВЫБЕРИТЕ ВИД СПОРТА" })).toContainText("Силовые тренировки");
+  await expect(page.getByRole("region", { name: "ПОЧЕМУ SPORT GEAR" })).toContainText("Безопасные сессии");
 });
 
 test("switches the language from mobile navigation", async ({ page }) => {

--- a/frontend/src/components/Home/ActivityStrip/ActivityStrip.spec.tsx
+++ b/frontend/src/components/Home/ActivityStrip/ActivityStrip.spec.tsx
@@ -1,9 +1,15 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import i18n from "../../../i18n/i18n";
 
 import ActivityStrip from "./ActivityStrip";
 
 describe("ActivityStrip", () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage("en");
+  });
+
   it("presents activity areas without unsupported brand claims", () => {
     render(<ActivityStrip />);
 
@@ -14,6 +20,21 @@ describe("ActivityStrip", () => {
       "Play",
       "Recover",
       "Explore",
+    ]);
+  });
+
+  it("translates the activity labels and accessible name", async () => {
+    await i18n.changeLanguage("ru");
+
+    render(<ActivityStrip />);
+
+    expect(screen.getByRole("group", { name: "Направления Sport Gear" })).toBeInTheDocument();
+    expect(screen.getAllByRole("listitem").map((item) => item.textContent)).toEqual([
+      "Бег",
+      "Тренировки",
+      "Игры",
+      "Восстановление",
+      "Активный отдых",
     ]);
   });
 });

--- a/frontend/src/components/Home/ActivityStrip/ActivityStrip.tsx
+++ b/frontend/src/components/Home/ActivityStrip/ActivityStrip.tsx
@@ -1,13 +1,23 @@
+import { useTranslation } from "react-i18next";
+
 import "./ActivityStrip.scss";
 
-const activities = ["Run", "Train", "Play", "Recover", "Explore"];
+const activityKeys = [
+  "activities.run",
+  "activities.train",
+  "activities.play",
+  "activities.recover",
+  "activities.explore",
+] as const;
 
 const ActivityStrip = () => {
+  const { t } = useTranslation("common");
+
   return (
-    <div aria-label="Sport Gear activities" className="activity-strip" role="group">
+    <div aria-label={t("activities.region")} className="activity-strip" role="group">
       <ul>
-        {activities.map((activity) => (
-          <li key={activity}>{activity}</li>
+        {activityKeys.map((activityKey) => (
+          <li key={activityKey}>{t(activityKey)}</li>
         ))}
       </ul>
     </div>

--- a/frontend/src/components/Home/CategoryShowcase/CategoryShowcase.spec.tsx
+++ b/frontend/src/components/Home/CategoryShowcase/CategoryShowcase.spec.tsx
@@ -1,10 +1,16 @@
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import i18n from "../../../i18n/i18n";
 
 import CategoryShowcase from "./CategoryShowcase";
 
 describe("CategoryShowcase", () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage("en");
+  });
+
   it("links the visual tiles to real seeded catalog categories", () => {
     render(
       <MemoryRouter>
@@ -17,5 +23,22 @@ describe("CategoryShowcase", () => {
     expect(screen.getByRole("link", { name: "Running" })).toHaveAttribute("href", "/catalog/shoes");
     expect(screen.getByRole("link", { name: "Strength" })).toHaveAttribute("href", "/catalog/fitness/strength");
     expect(screen.getByRole("link", { name: "Yoga" })).toHaveAttribute("href", "/catalog/fitness/yoga");
+  });
+
+  it("renders translated category labels without changing their destinations", async () => {
+    await i18n.changeLanguage("ru");
+
+    render(
+      <MemoryRouter>
+        <CategoryShowcase />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole("region", { name: "ВЫБЕРИТЕ ВИД СПОРТА" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Футбол" })).toHaveAttribute("href", "/catalog/balls/football");
+    expect(screen.getByRole("link", { name: "Силовые тренировки" })).toHaveAttribute(
+      "href",
+      "/catalog/fitness/strength"
+    );
   });
 });

--- a/frontend/src/components/Home/CategoryShowcase/CategoryShowcase.tsx
+++ b/frontend/src/components/Home/CategoryShowcase/CategoryShowcase.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 
 import { H2 } from "../../common/headings/H2";
@@ -7,38 +8,40 @@ import "./CategoryShowcase.scss";
 
 const categoryTiles = [
   {
-    name: "Football",
+    labelKey: "categories.football",
     href: "/catalog/balls/football",
     image: "https://images.unsplash.com/photo-1614632537190-23e4146777db?auto=format&fit=crop&w=1200&q=80",
   },
   {
-    name: "Running",
+    labelKey: "categories.running",
     href: "/catalog/shoes",
     image: "https://images.unsplash.com/photo-1542291026-7eec264c27ff?auto=format&fit=crop&w=1200&q=80",
   },
   {
-    name: "Strength",
+    labelKey: "categories.strength",
     href: "/catalog/fitness/strength",
     image: "https://images.unsplash.com/photo-1581009146145-b5ef050c2e1e?auto=format&fit=crop&w=1200&q=80",
   },
   {
-    name: "Yoga",
+    labelKey: "categories.yoga",
     href: "/catalog/fitness/yoga",
     image: "https://images.unsplash.com/photo-1601925260368-ae2f83cf8b7f?auto=format&fit=crop&w=1200&q=80",
   },
-];
+] as const;
 
 const CategoryShowcase = () => {
+  const { t } = useTranslation("common");
+
   return (
     <section aria-labelledby="category-showcase-title" className="category-showcase">
       <PageContainer className="category-showcase__container">
-        <H2 id="category-showcase-title" text="BROWSE BY SPORT" />
+        <H2 id="category-showcase-title" text={t("categories.heading")} />
 
         <div className="category-showcase__grid">
-          {categoryTiles.map(({ name, href, image }) => (
-            <Link className="category-showcase__tile" key={name} to={href}>
+          {categoryTiles.map(({ labelKey, href, image }) => (
+            <Link className="category-showcase__tile" key={labelKey} to={href}>
               <img alt="" loading="lazy" src={image} />
-              <span>{name}</span>
+              <span>{t(labelKey)}</span>
             </Link>
           ))}
         </div>

--- a/frontend/src/components/Home/HomeHero/HomeHero.spec.tsx
+++ b/frontend/src/components/Home/HomeHero/HomeHero.spec.tsx
@@ -1,10 +1,16 @@
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import i18n from "../../../i18n/i18n";
 
 import HomeHero from "./HomeHero";
 
 describe("HomeHero", () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage("en");
+  });
+
   it("introduces the storefront with a catalog action and truthful demo metrics", () => {
     render(
       <MemoryRouter>
@@ -17,5 +23,22 @@ describe("HomeHero", () => {
     expect(screen.getByText("8+")).toBeInTheDocument();
     expect(screen.getByText("Demo products")).toBeInTheDocument();
     expect(screen.getByRole("img", { name: "Athlete running stadium steps" })).toBeInTheDocument();
+  });
+
+  it("renders localized content in German", async () => {
+    await i18n.changeLanguage("de");
+
+    render(
+      <MemoryRouter>
+        <HomeHero />
+      </MemoryRouter>
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "FINDE AUSRÜSTUNG, DIE ZU DEINEN ZIELEN PASST", level: 1 })
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Jetzt shoppen" })).toHaveAttribute("href", "/catalog");
+    expect(screen.getByText("Demo-Produkte")).toBeInTheDocument();
+    expect(screen.getByRole("img", { name: "Athletin läuft Stadiontreppen hinauf" })).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/Home/HomeHero/HomeHero.tsx
+++ b/frontend/src/components/Home/HomeHero/HomeHero.tsx
@@ -1,4 +1,5 @@
 import { PiStarFourFill } from "react-icons/pi";
+import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 
 import { H1 } from "../../common/headings/H1";
@@ -7,38 +8,38 @@ import { PageContainer } from "../../common/PageContainer/PageContainer";
 import "./HomeHero.scss";
 
 const heroStats = [
-  { value: "8+", label: "Demo products" },
-  { value: "4+", label: "Gear categories" },
-  { value: "100%", label: "Server-priced" },
-];
+  { value: "8+", labelKey: "homeHero.demoProducts" },
+  { value: "4+", labelKey: "homeHero.gearCategories" },
+  { value: "100%", labelKey: "homeHero.serverPriced" },
+] as const;
 
 const HERO_IMAGE = "https://images.unsplash.com/photo-1538805060514-97d9cc17730c?auto=format&fit=crop&w=1600&q=85";
 
 const HomeHero = () => {
+  const { t } = useTranslation("common");
+
   return (
     <section className="home-hero">
       <PageContainer className="home-hero__container">
         <div className="home-hero__content">
-          <H1 className="home-hero__title" text="FIND GEAR THAT MATCHES YOUR GOALS" />
-          <p className="home-hero__description">
-            Explore dependable equipment for the field, court, gym, and every training session in between.
-          </p>
+          <H1 className="home-hero__title" text={t("homeHero.title")} />
+          <p className="home-hero__description">{t("homeHero.description")}</p>
           <Link className="home-hero__cta" to="/catalog">
-            Shop now
+            {t("homeHero.cta")}
           </Link>
 
           <dl className="home-hero__stats">
-            {heroStats.map(({ value, label }) => (
-              <div className="home-hero__stat" key={label}>
+            {heroStats.map(({ value, labelKey }) => (
+              <div className="home-hero__stat" key={labelKey}>
                 <dt>{value}</dt>
-                <dd>{label}</dd>
+                <dd>{t(labelKey)}</dd>
               </div>
             ))}
           </dl>
         </div>
 
         <div className="home-hero__media">
-          <img alt="Athlete running stadium steps" className="home-hero__image" src={HERO_IMAGE} />
+          <img alt={t("homeHero.imageAlt")} className="home-hero__image" src={HERO_IMAGE} />
           <PiStarFourFill aria-hidden="true" className="home-hero__sparkle home-hero__sparkle--large" />
           <PiStarFourFill aria-hidden="true" className="home-hero__sparkle home-hero__sparkle--small" />
         </div>

--- a/frontend/src/components/Home/HomeProductSection/HomeProductSection.spec.tsx
+++ b/frontend/src/components/Home/HomeProductSection/HomeProductSection.spec.tsx
@@ -1,8 +1,9 @@
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { Product } from "../../../services/productService/types";
+import i18n from "../../../i18n/i18n";
 
 import HomeProductSection from "./HomeProductSection";
 
@@ -27,6 +28,10 @@ const products: Product[] = [
 ];
 
 describe("HomeProductSection", () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage("en");
+  });
+
   it("labels the section and presents showcase products with a catalog link", () => {
     render(
       <MemoryRouter>
@@ -38,5 +43,17 @@ describe("HomeProductSection", () => {
     expect(screen.getByTestId("product-list")).toHaveAttribute("data-variant", "showcase");
     expect(screen.getByText("Running Shoes")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "View all" })).toHaveAttribute("href", "/catalog");
+  });
+
+  it("localizes the catalog action", async () => {
+    await i18n.changeLanguage("de");
+
+    render(
+      <MemoryRouter>
+        <HomeProductSection products={products} title="Neu eingetroffen" />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole("link", { name: "Alle ansehen" })).toHaveAttribute("href", "/catalog");
   });
 });

--- a/frontend/src/components/Home/HomeProductSection/HomeProductSection.tsx
+++ b/frontend/src/components/Home/HomeProductSection/HomeProductSection.tsx
@@ -1,4 +1,5 @@
 import { useId, type ComponentPropsWithoutRef } from "react";
+import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 
 import type { Product } from "../../../services/productService/types";
@@ -21,6 +22,7 @@ const HomeProductSection = ({
   className = "",
   ...props
 }: HomeProductSectionProps) => {
+  const { t } = useTranslation("common");
   const titleId = useId();
   const sectionClassName = `home-product-section ${className}`.trim();
 
@@ -30,7 +32,7 @@ const HomeProductSection = ({
         <H2 className="home-product-section__title" id={titleId} text={title} />
         <ProductList className="home-product-section__list" products={products} variant="showcase" />
         <Link className="home-product-section__view-all" to={viewAllHref}>
-          View all
+          {t("home.viewAll")}
         </Link>
       </PageContainer>
     </section>

--- a/frontend/src/components/Home/StoreHighlights/StoreHighlights.spec.tsx
+++ b/frontend/src/components/Home/StoreHighlights/StoreHighlights.spec.tsx
@@ -1,12 +1,15 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import i18n from "../../../i18n/i18n";
+
 import StoreHighlights from "./StoreHighlights";
 
 const scrollBy = vi.fn();
 
 describe("StoreHighlights", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    await i18n.changeLanguage("en");
     scrollBy.mockReset();
     Object.defineProperty(HTMLElement.prototype, "scrollBy", {
       configurable: true,
@@ -27,5 +30,18 @@ describe("StoreHighlights", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Previous advantages" }));
     expect(scrollBy).toHaveBeenCalledWith({ behavior: "smooth", left: -360 });
+  });
+
+  it("localizes cards, list, and carousel controls", async () => {
+    await i18n.changeLanguage("ru");
+
+    render(<StoreHighlights />);
+
+    expect(screen.getByRole("region", { name: "ПОЧЕМУ SPORT GEAR" })).toBeInTheDocument();
+    expect(screen.getByRole("list", { name: "Преимущества магазина" })).toBeInTheDocument();
+    expect(screen.getByText("Цены рассчитывает сервер")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Следующие преимущества" }));
+    expect(scrollBy).toHaveBeenCalledWith({ behavior: "smooth", left: 360 });
   });
 });

--- a/frontend/src/components/Home/StoreHighlights/StoreHighlights.tsx
+++ b/frontend/src/components/Home/StoreHighlights/StoreHighlights.tsx
@@ -1,6 +1,7 @@
 import { useRef } from "react";
 import { FiArrowLeft, FiArrowRight } from "react-icons/fi";
 import { IoCheckmarkCircle } from "react-icons/io5";
+import { useTranslation } from "react-i18next";
 
 import { H2 } from "../../common/headings/H2";
 import { IconButton } from "../../common/IconButton/IconButton";
@@ -10,26 +11,25 @@ import "./StoreHighlights.scss";
 
 const highlights = [
   {
-    title: "Server-priced catalog",
-    description: "Product prices, discounts, and availability come from the NestJS API instead of browser storage.",
+    titleKey: "highlights.serverTitle",
+    descriptionKey: "highlights.serverDescription",
   },
   {
-    title: "A cart that follows you",
-    description: "Start shopping anonymously and keep the same items when you create an account or sign in.",
+    titleKey: "highlights.cartTitle",
+    descriptionKey: "highlights.cartDescription",
   },
   {
-    title: "Responsive by design",
-    description:
-      "The storefront is structured for phones, tablets, and desktop screens using one accessible interface.",
+    titleKey: "highlights.responsiveTitle",
+    descriptionKey: "highlights.responsiveDescription",
   },
   {
-    title: "Secure account sessions",
-    description:
-      "HttpOnly cookies, rotating refresh sessions, and CSRF protection keep credentials out of frontend code.",
+    titleKey: "highlights.sessionsTitle",
+    descriptionKey: "highlights.sessionsDescription",
   },
-];
+] as const;
 
 const StoreHighlights = () => {
+  const { t } = useTranslation("common");
   const listRef = useRef<HTMLDivElement>(null);
 
   const scroll = (direction: -1 | 1) => {
@@ -44,19 +44,24 @@ const StoreHighlights = () => {
     <section aria-labelledby="store-highlights-title" className="store-highlights">
       <PageContainer>
         <div className="store-highlights__header">
-          <H2 id="store-highlights-title" text="WHY SPORT GEAR" />
+          <H2 id="store-highlights-title" text={t("highlights.heading")} />
           <div className="store-highlights__controls">
-            <IconButton icon={<FiArrowLeft />} label="Previous advantages" onClick={() => scroll(-1)} size="small" />
-            <IconButton icon={<FiArrowRight />} label="Next advantages" onClick={() => scroll(1)} size="small" />
+            <IconButton
+              icon={<FiArrowLeft />}
+              label={t("highlights.previous")}
+              onClick={() => scroll(-1)}
+              size="small"
+            />
+            <IconButton icon={<FiArrowRight />} label={t("highlights.next")} onClick={() => scroll(1)} size="small" />
           </div>
         </div>
 
-        <div aria-label="Store advantages" className="store-highlights__list" ref={listRef} role="list">
-          {highlights.map(({ title, description }) => (
-            <article className="store-highlights__card" key={title} role="listitem">
+        <div aria-label={t("highlights.list")} className="store-highlights__list" ref={listRef} role="list">
+          {highlights.map(({ titleKey, descriptionKey }) => (
+            <article className="store-highlights__card" key={titleKey} role="listitem">
               <IoCheckmarkCircle aria-hidden="true" className="store-highlights__check" />
-              <h3>{title}</h3>
-              <p>{description}</p>
+              <h3>{t(titleKey)}</h3>
+              <p>{t(descriptionKey)}</p>
             </article>
           ))}
         </div>

--- a/frontend/src/i18n/locales/de/common.ts
+++ b/frontend/src/i18n/locales/de/common.ts
@@ -88,4 +88,22 @@ export const deCommon = {
     emailRequired: "Gib deine E-Mail-Adresse ein.",
     invalidEmail: "Gib eine gültige E-Mail-Adresse ein, zum Beispiel user@example.com.",
   },
+  homeHero: {
+    title: "FINDE AUSRÜSTUNG, DIE ZU DEINEN ZIELEN PASST",
+    description:
+      "Entdecke zuverlässige Ausrüstung für Sportplatz, Halle, Fitnessstudio und jede Trainingseinheit dazwischen.",
+    cta: "Jetzt shoppen",
+    imageAlt: "Athletin läuft Stadiontreppen hinauf",
+    demoProducts: "Demo-Produkte",
+    gearCategories: "Ausrüstungskategorien",
+    serverPriced: "Serverbasierte Preise",
+  },
+  activities: {
+    region: "Sportarten bei Sport Gear",
+    run: "Laufen",
+    train: "Trainieren",
+    play: "Spielen",
+    recover: "Regenerieren",
+    explore: "Entdecken",
+  },
 } satisfies CommonTranslations;

--- a/frontend/src/i18n/locales/de/common.ts
+++ b/frontend/src/i18n/locales/de/common.ts
@@ -121,4 +121,22 @@ export const deCommon = {
     strength: "Krafttraining",
     yoga: "Yoga",
   },
+  highlights: {
+    heading: "WARUM SPORT GEAR",
+    list: "Vorteile des Shops",
+    previous: "Vorherige Vorteile",
+    next: "Nächste Vorteile",
+    serverTitle: "Preise direkt vom Server",
+    serverDescription:
+      "Produktpreise, Rabatte und Verfügbarkeit kommen aus der NestJS API und nicht aus dem Browser-Speicher.",
+    cartTitle: "Ein Warenkorb, der dich begleitet",
+    cartDescription:
+      "Beginne anonym einzukaufen und behalte deine Artikel, wenn du ein Konto erstellst oder dich anmeldest.",
+    responsiveTitle: "Responsiv entwickelt",
+    responsiveDescription:
+      "Der Shop bietet auf Smartphones, Tablets und Desktop-Geräten eine einheitliche, barrierearme Oberfläche.",
+    sessionsTitle: "Sichere Kontositzungen",
+    sessionsDescription:
+      "HttpOnly-Cookies, rotierende Refresh-Sitzungen und CSRF-Schutz halten Zugangsdaten vom Frontend-Code fern.",
+  },
 } satisfies CommonTranslations;

--- a/frontend/src/i18n/locales/de/common.ts
+++ b/frontend/src/i18n/locales/de/common.ts
@@ -106,4 +106,19 @@ export const deCommon = {
     recover: "Regenerieren",
     explore: "Entdecken",
   },
+  home: {
+    loading: "Die neuesten Produkte werden geladen...",
+    loadError: "Die Produktauswahl konnte nicht geladen werden. Bitte versuche es erneut.",
+    retry: "Erneut versuchen",
+    newArrivals: "Neu eingetroffen",
+    moreGear: "Ausrüstung für jedes Ziel",
+    viewAll: "Alle ansehen",
+  },
+  categories: {
+    heading: "NACH SPORTART ENTDECKEN",
+    football: "Fußball",
+    running: "Laufen",
+    strength: "Krafttraining",
+    yoga: "Yoga",
+  },
 } satisfies CommonTranslations;

--- a/frontend/src/i18n/locales/en/common.ts
+++ b/frontend/src/i18n/locales/en/common.ts
@@ -86,6 +86,23 @@ export const enCommon = {
     emailRequired: "Enter your email address.",
     invalidEmail: "Enter a valid email address, for example user@example.com.",
   },
+  homeHero: {
+    title: "FIND GEAR THAT MATCHES YOUR GOALS",
+    description: "Explore dependable equipment for the field, court, gym, and every training session in between.",
+    cta: "Shop now",
+    imageAlt: "Athlete running stadium steps",
+    demoProducts: "Demo products",
+    gearCategories: "Gear categories",
+    serverPriced: "Server-priced",
+  },
+  activities: {
+    region: "Sport Gear activities",
+    run: "Run",
+    train: "Train",
+    play: "Play",
+    recover: "Recover",
+    explore: "Explore",
+  },
 } as const;
 
 export type CommonTranslations = {

--- a/frontend/src/i18n/locales/en/common.ts
+++ b/frontend/src/i18n/locales/en/common.ts
@@ -103,6 +103,21 @@ export const enCommon = {
     recover: "Recover",
     explore: "Explore",
   },
+  home: {
+    loading: "Loading the latest gear...",
+    loadError: "We couldn't load the product selection. Please try again.",
+    retry: "Try again",
+    newArrivals: "New arrivals",
+    moreGear: "Gear for every goal",
+    viewAll: "View all",
+  },
+  categories: {
+    heading: "BROWSE BY SPORT",
+    football: "Football",
+    running: "Running",
+    strength: "Strength",
+    yoga: "Yoga",
+  },
 } as const;
 
 export type CommonTranslations = {

--- a/frontend/src/i18n/locales/en/common.ts
+++ b/frontend/src/i18n/locales/en/common.ts
@@ -118,6 +118,23 @@ export const enCommon = {
     strength: "Strength",
     yoga: "Yoga",
   },
+  highlights: {
+    heading: "WHY SPORT GEAR",
+    list: "Store advantages",
+    previous: "Previous advantages",
+    next: "Next advantages",
+    serverTitle: "Server-priced catalog",
+    serverDescription:
+      "Product prices, discounts, and availability come from the NestJS API instead of browser storage.",
+    cartTitle: "A cart that follows you",
+    cartDescription: "Start shopping anonymously and keep the same items when you create an account or sign in.",
+    responsiveTitle: "Responsive by design",
+    responsiveDescription:
+      "The storefront is structured for phones, tablets, and desktop screens using one accessible interface.",
+    sessionsTitle: "Secure account sessions",
+    sessionsDescription:
+      "HttpOnly cookies, rotating refresh sessions, and CSRF protection keep credentials out of frontend code.",
+  },
 } as const;
 
 export type CommonTranslations = {

--- a/frontend/src/i18n/locales/ru/common.ts
+++ b/frontend/src/i18n/locales/ru/common.ts
@@ -120,4 +120,19 @@ export const ruCommon = {
     strength: "Силовые тренировки",
     yoga: "Йога",
   },
+  highlights: {
+    heading: "ПОЧЕМУ SPORT GEAR",
+    list: "Преимущества магазина",
+    previous: "Предыдущие преимущества",
+    next: "Следующие преимущества",
+    serverTitle: "Цены рассчитывает сервер",
+    serverDescription: "Цены, скидки и доступность товаров поступают из NestJS API, а не из хранилища браузера.",
+    cartTitle: "Корзина всегда с вами",
+    cartDescription: "Начните покупки без регистрации и сохраните товары после создания аккаунта или входа.",
+    responsiveTitle: "Адаптивный интерфейс",
+    responsiveDescription: "Единый доступный интерфейс магазина работает на телефонах, планшетах и компьютерах.",
+    sessionsTitle: "Безопасные сессии",
+    sessionsDescription:
+      "HttpOnly cookies, ротация refresh-сессий и CSRF-защита не допускают попадания данных авторизации во frontend-код.",
+  },
 } satisfies CommonTranslations;

--- a/frontend/src/i18n/locales/ru/common.ts
+++ b/frontend/src/i18n/locales/ru/common.ts
@@ -105,4 +105,19 @@ export const ruCommon = {
     recover: "Восстановление",
     explore: "Активный отдых",
   },
+  home: {
+    loading: "Загружаем новые товары...",
+    loadError: "Не удалось загрузить подборку товаров. Попробуйте ещё раз.",
+    retry: "Попробовать снова",
+    newArrivals: "Новинки",
+    moreGear: "Экипировка для любых целей",
+    viewAll: "Смотреть все",
+  },
+  categories: {
+    heading: "ВЫБЕРИТЕ ВИД СПОРТА",
+    football: "Футбол",
+    running: "Бег",
+    strength: "Силовые тренировки",
+    yoga: "Йога",
+  },
 } satisfies CommonTranslations;

--- a/frontend/src/i18n/locales/ru/common.ts
+++ b/frontend/src/i18n/locales/ru/common.ts
@@ -88,4 +88,21 @@ export const ruCommon = {
     emailRequired: "Введите электронную почту.",
     invalidEmail: "Введите корректный адрес, например user@example.com.",
   },
+  homeHero: {
+    title: "НАЙДИ ЭКИПИРОВКУ ДЛЯ СВОИХ ЦЕЛЕЙ",
+    description: "Надёжная экипировка для поля, корта, тренажёрного зала и любых тренировок.",
+    cta: "Перейти в магазин",
+    imageAlt: "Спортсменка поднимается по ступеням стадиона",
+    demoProducts: "Демо-товаров",
+    gearCategories: "Категории товаров",
+    serverPriced: "Цены с сервера",
+  },
+  activities: {
+    region: "Направления Sport Gear",
+    run: "Бег",
+    train: "Тренировки",
+    play: "Игры",
+    recover: "Восстановление",
+    explore: "Активный отдых",
+  },
 } satisfies CommonTranslations;

--- a/frontend/src/pages/Home/Home.spec.tsx
+++ b/frontend/src/pages/Home/Home.spec.tsx
@@ -1,8 +1,9 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { fetchProducts } from "../../services/productService/productService";
 import type { Product } from "../../services/productService/types";
+import i18n from "../../i18n/i18n";
 
 import HomePage from "./Home";
 
@@ -28,7 +29,8 @@ const products: Product[] = Array.from({ length: 8 }, (_, index) => ({
 }));
 
 describe("HomePage", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    await i18n.changeLanguage("en");
     vi.mocked(fetchProducts).mockReset();
   });
 
@@ -52,5 +54,20 @@ describe("HomePage", () => {
 
     await waitFor(() => expect(fetchProducts).toHaveBeenCalledTimes(2));
     expect(await screen.findByText("New arrivals")).toBeInTheDocument();
+  });
+
+  it("updates an existing error message when the language changes", async () => {
+    vi.mocked(fetchProducts).mockRejectedValue(new Error("Unavailable"));
+    render(<HomePage />);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("couldn't load the product selection");
+
+    await act(async () => {
+      await i18n.changeLanguage("de");
+    });
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Die Produktauswahl konnte nicht geladen werden");
+    expect(screen.getByRole("button", { name: "Erneut versuchen" })).toBeInTheDocument();
+    expect(fetchProducts).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/pages/Home/Home.tsx
+++ b/frontend/src/pages/Home/Home.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 
 import ActivityStrip from "../../components/Home/ActivityStrip/ActivityStrip";
 import CategoryShowcase from "../../components/Home/CategoryShowcase/CategoryShowcase";
@@ -16,9 +17,10 @@ const HOME_PRODUCT_LIMIT = 8;
 const HOME_SECTION_SIZE = 4;
 
 export default function HomePage() {
+  const { t } = useTranslation("common");
   const [products, setProducts] = useState<Product[]>([]);
   const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const [hasError, setHasError] = useState(false);
   const [reloadKey, setReloadKey] = useState(0);
 
   useEffect(() => {
@@ -26,13 +28,13 @@ export default function HomePage() {
 
     const loadProducts = async () => {
       setIsLoading(true);
-      setError(null);
+      setHasError(false);
 
       try {
         const nextProducts = await fetchProducts({ limit: HOME_PRODUCT_LIMIT });
         if (!cancelled) setProducts(nextProducts);
       } catch {
-        if (!cancelled) setError("We couldn't load the product selection. Please try again.");
+        if (!cancelled) setHasError(true);
       } finally {
         if (!cancelled) setIsLoading(false);
       }
@@ -56,25 +58,25 @@ export default function HomePage() {
       {isLoading && (
         <PageContainer aria-live="polite" className="home-page__feedback" role="status">
           <span className="home-page__loader" />
-          Loading the latest gear...
+          {t("home.loading")}
         </PageContainer>
       )}
 
-      {!isLoading && error && (
+      {!isLoading && hasError && (
         <PageContainer className="home-page__feedback home-page__feedback--error" role="alert">
-          <p>{error}</p>
+          <p>{t("home.loadError")}</p>
           <Button
             className="btn-medium home-page__retry"
             onClick={() => setReloadKey((current) => current + 1)}
-            text="Try again"
+            text={t("home.retry")}
           />
         </PageContainer>
       )}
 
-      {!isLoading && !error && (
+      {!isLoading && !hasError && (
         <>
-          {newArrivals.length > 0 && <HomeProductSection products={newArrivals} title="New arrivals" />}
-          {moreGear.length > 0 && <HomeProductSection products={moreGear} title="Gear for every goal" />}
+          {newArrivals.length > 0 && <HomeProductSection products={newArrivals} title={t("home.newArrivals")} />}
+          {moreGear.length > 0 && <HomeProductSection products={moreGear} title={t("home.moreGear")} />}
         </>
       )}
 


### PR DESCRIPTION
## Summary

- localize the Home hero, CTA, statistics, activity strip, product sections, and sport categories
- localize the store highlights carousel, including accessible labels and navigation controls
- keep API errors language-reactive by storing error state instead of translated copy
- extend unit and Playwright coverage for English, German, and Russian Home content

## Why

The storefront shell already supports English, German, and Russian, but the Home page still contained hardcoded English copy. This PR completes the next i18n slice so language changes apply consistently across the main landing experience.
