### PR TITLE
feat(frontend): localize the catalog experience

### DIFF
--- a/e2e/store.spec.ts
+++ b/e2e/store.spec.ts
@@ -68,6 +68,33 @@ test("switches the language from mobile navigation", async ({ page }) => {
   await expect(page.getByRole("button", { name: "Текущий язык: Русский" })).toContainText("RU");
 });
 
+test("localizes catalog controls across desktop and mobile layouts", async ({ page }) => {
+  await page.goto("/catalog");
+
+  await page.getByRole("button", { name: "Current language: English" }).click();
+  await page.getByRole("menuitemradio", { name: "DE Deutsch" }).click();
+
+  await expect(page.getByRole("heading", { level: 1, name: "Alle Produkte" })).toBeVisible();
+  await expect(page.getByText("1-6 von 8 Produkten")).toBeVisible();
+  await expect(page.getByRole("navigation", { name: "Breadcrumb-Navigation" })).toContainText("StartseiteKatalog");
+  await expect(page.getByRole("region", { name: "Kategorien" })).toContainText("Alle Produkte");
+  await expect(page.getByRole("combobox", { name: "Produkte sortieren" })).toHaveValue("default");
+  await expect(page.getByRole("button", { name: "In den Warenkorb" }).first()).toBeVisible();
+  await expect(page.locator(".product-card__current-price").first()).toContainText(/\d+,\d{2}\s€/);
+  await expect(page.getByRole("navigation", { name: "Katalogseiten" })).toBeVisible();
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.getByRole("button", { name: "Katalogoptionen öffnen" }).click();
+
+  const drawer = page.getByRole("dialog", { name: "Katalogoptionen" });
+  await expect(drawer).toBeVisible();
+  await expect(drawer.getByRole("combobox", { name: "Produkte sortieren" })).toBeVisible();
+  await expect(drawer.getByRole("region", { name: "Kategorien" })).toContainText("Alle Produkte");
+
+  await drawer.getByRole("button", { name: "Katalogoptionen schließen" }).click();
+  await expect(drawer).toHaveCount(0);
+});
+
 test("registers, shops with a promo code, opens profile and logs out", async ({ page }) => {
   const email = `playwright-${Date.now()}@example.com`;
 

--- a/frontend/src/components/Breadcrumbs/Breadcrumbs.spec.tsx
+++ b/frontend/src/components/Breadcrumbs/Breadcrumbs.spec.tsx
@@ -1,10 +1,16 @@
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import i18n from "../../i18n/i18n";
 
 import Breadcrumbs from "./Breadcrumbs";
 
 describe("Breadcrumbs", () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage("en");
+  });
+
   it("marks the last category as the current page", () => {
     render(
       <MemoryRouter>
@@ -32,5 +38,19 @@ describe("Breadcrumbs", () => {
     expect(screen.getByRole("navigation", { name: "Breadcrumb" })).toHaveTextContent("HomeCart");
     expect(screen.queryByText("Catalog")).not.toBeInTheDocument();
     expect(screen.getByText("Cart")).toHaveAttribute("aria-current", "page");
+  });
+
+  it("localizes built-in navigation labels without changing dynamic crumbs", async () => {
+    await i18n.changeLanguage("de");
+
+    render(
+      <MemoryRouter>
+        <Breadcrumbs crumbs={[{ name: "Fitness", path: "/catalog/fitness" }]} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole("navigation", { name: "Breadcrumb-Navigation" })).toHaveTextContent(
+      "StartseiteKatalogFitness"
+    );
   });
 });

--- a/frontend/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/frontend/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -1,4 +1,5 @@
 import { PiCaretRight } from "react-icons/pi";
+import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 
 import "./Breadcrumbs.scss";
@@ -16,16 +17,22 @@ interface BreadcrumbsProps {
 const BreadcrumbSeparator = () => <PiCaretRight aria-hidden="true" className="breadcrumbs__separator" />;
 
 const Breadcrumbs = ({ crumbs, includeCatalog = true }: BreadcrumbsProps) => {
+  const { t } = useTranslation("common");
+
   return (
-    <nav aria-label="Breadcrumb" className="breadcrumbs">
+    <nav aria-label={t("breadcrumbs.navigation")} className="breadcrumbs">
       <ol>
         <li>
-          <Link to="/">Home</Link>
+          <Link to="/">{t("breadcrumbs.home")}</Link>
           {(includeCatalog || crumbs.length > 0) && <BreadcrumbSeparator />}
         </li>
         {includeCatalog && (
           <li>
-            {crumbs.length ? <Link to="/catalog">Catalog</Link> : <span aria-current="page">Catalog</span>}
+            {crumbs.length ? (
+              <Link to="/catalog">{t("breadcrumbs.catalog")}</Link>
+            ) : (
+              <span aria-current="page">{t("breadcrumbs.catalog")}</span>
+            )}
             {crumbs.length > 0 && <BreadcrumbSeparator />}
           </li>
         )}

--- a/frontend/src/components/Catalog/CategoryFilter/CategoryFilter.spec.tsx
+++ b/frontend/src/components/Catalog/CategoryFilter/CategoryFilter.spec.tsx
@@ -1,10 +1,16 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import i18n from "../../../i18n/i18n";
 
 import { CategoryFilter } from "./CategoryFilter";
 
 describe("CategoryFilter", () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage("en");
+  });
+
   it("renders supported category links and closes after navigation", () => {
     const onNavigate = vi.fn();
 
@@ -22,5 +28,18 @@ describe("CategoryFilter", () => {
 
     fireEvent.click(screen.getByRole("link", { name: "Balls" }));
     expect(onNavigate).toHaveBeenCalledOnce();
+  });
+
+  it("localizes the section and all-products link", async () => {
+    await i18n.changeLanguage("ru");
+
+    render(
+      <MemoryRouter>
+        <CategoryFilter items={[]} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole("region", { name: "Категории" })).toBeVisible();
+    expect(screen.getByRole("link", { name: "Все товары" })).toHaveAttribute("href", "/catalog");
   });
 });

--- a/frontend/src/components/Catalog/CategoryFilter/CategoryFilter.tsx
+++ b/frontend/src/components/Catalog/CategoryFilter/CategoryFilter.tsx
@@ -1,5 +1,6 @@
 import { useId } from "react";
 import { PiCaretRight, PiSlidersHorizontal } from "react-icons/pi";
+import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 
 import "./CategoryFilter.scss";
@@ -18,19 +19,20 @@ type CategoryFilterProps = {
 };
 
 export function CategoryFilter({ className = "", items, onNavigate }: CategoryFilterProps) {
+  const { t } = useTranslation("common");
   const titleId = useId();
 
   return (
     <section aria-labelledby={titleId} className={`category-filter ${className}`.trim()}>
       <div className="category-filter__header">
-        <h2 id={titleId}>Categories</h2>
+        <h2 id={titleId}>{t("catalogNavigation.categories")}</h2>
         <PiSlidersHorizontal aria-hidden="true" />
       </div>
 
       <ul className="category-filter__list">
         <li>
           <Link className="category-filter__link" onClick={onNavigate} to="/catalog">
-            <span>All products</span>
+            <span>{t("catalogNavigation.allProducts")}</span>
             <PiCaretRight aria-hidden="true" />
           </Link>
         </li>

--- a/frontend/src/components/Catalog/FilterDrawer/FilterDrawer.spec.tsx
+++ b/frontend/src/components/Catalog/FilterDrawer/FilterDrawer.spec.tsx
@@ -1,9 +1,15 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import i18n from "../../../i18n/i18n";
 
 import { FilterDrawer } from "./FilterDrawer";
 
 describe("FilterDrawer", () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage("en");
+  });
+
   it("renders as a modal dialog and closes with Escape", () => {
     const onClose = vi.fn();
 
@@ -28,5 +34,18 @@ describe("FilterDrawer", () => {
     );
 
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("localizes the dialog and close action", async () => {
+    await i18n.changeLanguage("de");
+
+    render(
+      <FilterDrawer isOpen onClose={vi.fn()}>
+        <p>Filter</p>
+      </FilterDrawer>
+    );
+
+    expect(screen.getByRole("dialog", { name: "Katalogoptionen" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Katalogoptionen schließen" })).toBeVisible();
   });
 });

--- a/frontend/src/components/Catalog/FilterDrawer/FilterDrawer.tsx
+++ b/frontend/src/components/Catalog/FilterDrawer/FilterDrawer.tsx
@@ -1,5 +1,6 @@
 import { useEffect, type ReactNode } from "react";
 import { PiX } from "react-icons/pi";
+import { useTranslation } from "react-i18next";
 
 import "./FilterDrawer.scss";
 
@@ -10,6 +11,8 @@ type FilterDrawerProps = {
 };
 
 export function FilterDrawer({ children, isOpen, onClose }: FilterDrawerProps) {
+  const { t } = useTranslation("common");
+
   useEffect(() => {
     if (!isOpen) return;
 
@@ -38,8 +41,8 @@ export function FilterDrawer({ children, isOpen, onClose }: FilterDrawerProps) {
     >
       <aside aria-labelledby="filter-drawer-title" aria-modal="true" className="filter-drawer" role="dialog">
         <div className="filter-drawer__header">
-          <h2 id="filter-drawer-title">Catalog options</h2>
-          <button aria-label="Close catalog options" onClick={onClose} type="button">
+          <h2 id="filter-drawer-title">{t("catalogNavigation.options")}</h2>
+          <button aria-label={t("catalogNavigation.closeOptions")} onClick={onClose} type="button">
             <PiX aria-hidden="true" />
           </button>
         </div>

--- a/frontend/src/components/Sorting/Sorting.spec.tsx
+++ b/frontend/src/components/Sorting/Sorting.spec.tsx
@@ -1,9 +1,15 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import i18n from "../../i18n/i18n";
 
 import Sorting from "./Sorting";
 
 describe("Sorting", () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage("en");
+  });
+
   it("shows the current sort and reports a new selection", () => {
     const onSortChange = vi.fn();
 
@@ -15,5 +21,19 @@ describe("Sorting", () => {
     fireEvent.change(select, { target: { value: "price asc" } });
 
     expect(onSortChange).toHaveBeenCalledWith("price asc");
+  });
+
+  it("localizes labels while preserving stable sort values", async () => {
+    await i18n.changeLanguage("de");
+    const onSortChange = vi.fn();
+
+    render(<Sorting currentSort="default" onSortChange={onSortChange} />);
+
+    const select = screen.getByRole("combobox", { name: "Produkte sortieren" });
+    expect(screen.getByText("Sortieren nach:")).toBeVisible();
+    expect(screen.getByRole("option", { name: "Preis: aufsteigend" })).toHaveValue("price asc");
+
+    fireEvent.change(select, { target: { value: "name desc" } });
+    expect(onSortChange).toHaveBeenCalledWith("name desc");
   });
 });

--- a/frontend/src/components/Sorting/Sorting.tsx
+++ b/frontend/src/components/Sorting/Sorting.tsx
@@ -1,4 +1,5 @@
 import { PiCaretDownBold } from "react-icons/pi";
+import { useTranslation } from "react-i18next";
 
 import "./Sorting.scss";
 
@@ -10,30 +11,30 @@ export interface SortingProps {
   className?: string;
 }
 
-const LABELS: Record<SortOption, string> = {
-  default: "Most relevant",
-  "price asc": "Price: low to high",
-  "price desc": "Price: high to low",
-  "name asc": "Name: A to Z",
-  "name desc": "Name: Z to A",
-};
-
-const SORT_OPTIONS = Object.entries(LABELS) as [SortOption, string][];
+const SORT_OPTIONS = [
+  { value: "default", labelKey: "sorting.relevance" },
+  { value: "price asc", labelKey: "sorting.priceAscending" },
+  { value: "price desc", labelKey: "sorting.priceDescending" },
+  { value: "name asc", labelKey: "sorting.nameAscending" },
+  { value: "name desc", labelKey: "sorting.nameDescending" },
+] as const satisfies ReadonlyArray<{ value: SortOption; labelKey: string }>;
 
 export const Sorting = ({ currentSort, onSortChange, className = "" }: SortingProps) => {
+  const { t } = useTranslation("common");
+
   return (
     <label className={`sorting ${className}`.trim()}>
-      <span className="sorting__label">Sort by:</span>
+      <span className="sorting__label">{t("sorting.label")}</span>
       <span className="sorting__control">
         <select
-          aria-label="Sort products"
+          aria-label={t("sorting.control")}
           className="sorting__select"
           onChange={(event) => onSortChange(event.target.value as SortOption)}
           value={currentSort}
         >
-          {SORT_OPTIONS.map(([value, label]) => (
+          {SORT_OPTIONS.map(({ value, labelKey }) => (
             <option key={value} value={value}>
-              {label}
+              {t(labelKey)}
             </option>
           ))}
         </select>

--- a/frontend/src/components/common/Pagination/Pagination.spec.tsx
+++ b/frontend/src/components/common/Pagination/Pagination.spec.tsx
@@ -1,9 +1,15 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import i18n from "../../../i18n/i18n";
 
 import { Pagination } from "./Pagination";
 
 describe("Pagination", () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage("en");
+  });
+
   it("moves between pages and marks the current page", () => {
     const onPageChange = vi.fn();
 
@@ -22,5 +28,16 @@ describe("Pagination", () => {
     const { container } = render(<Pagination currentPage={1} onPageChange={vi.fn()} pageSize={6} totalItems={6} />);
 
     expect(container).toBeEmptyDOMElement();
+  });
+
+  it("localizes navigation and generated page labels", async () => {
+    await i18n.changeLanguage("ru");
+
+    render(<Pagination currentPage={2} onPageChange={vi.fn()} pageSize={6} totalItems={18} />);
+
+    expect(screen.getByRole("navigation", { name: "Страницы каталога" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Предыдущая страница" })).toHaveTextContent("Назад");
+    expect(screen.getByRole("button", { name: "Перейти на страницу 2" })).toHaveAttribute("aria-current", "page");
+    expect(screen.getByRole("button", { name: "Следующая страница" })).toHaveTextContent("Вперёд");
   });
 });

--- a/frontend/src/components/common/Pagination/Pagination.tsx
+++ b/frontend/src/components/common/Pagination/Pagination.tsx
@@ -1,4 +1,5 @@
 import { PiArrowLeft, PiArrowRight } from "react-icons/pi";
+import { useTranslation } from "react-i18next";
 
 import "./Pagination.scss";
 
@@ -26,20 +27,21 @@ function paginationItems(currentPage: number, totalPages: number): PaginationIte
 }
 
 export function Pagination({ className = "", currentPage, onPageChange, pageSize, totalItems }: PaginationProps) {
+  const { t } = useTranslation("common");
   const totalPages = Math.ceil(totalItems / pageSize);
   if (totalPages <= 1) return null;
 
   return (
-    <nav aria-label="Catalog pagination" className={`pagination ${className}`.trim()}>
+    <nav aria-label={t("pagination.navigation")} className={`pagination ${className}`.trim()}>
       <button
-        aria-label="Previous page"
+        aria-label={t("pagination.previousPage")}
         className="pagination__direction"
         disabled={currentPage === 1}
         onClick={() => onPageChange(currentPage - 1)}
         type="button"
       >
         <PiArrowLeft aria-hidden="true" />
-        <span>Previous</span>
+        <span>{t("pagination.previous")}</span>
       </button>
 
       <div className="pagination__pages">
@@ -47,7 +49,7 @@ export function Pagination({ className = "", currentPage, onPageChange, pageSize
           typeof item === "number" ? (
             <button
               aria-current={item === currentPage ? "page" : undefined}
-              aria-label={`Go to page ${item}`}
+              aria-label={t("pagination.goToPage", { page: item })}
               className="pagination__page"
               key={item}
               onClick={() => onPageChange(item)}
@@ -64,13 +66,13 @@ export function Pagination({ className = "", currentPage, onPageChange, pageSize
       </div>
 
       <button
-        aria-label="Next page"
+        aria-label={t("pagination.nextPage")}
         className="pagination__direction"
         disabled={currentPage === totalPages}
         onClick={() => onPageChange(currentPage + 1)}
         type="button"
       >
-        <span>Next</span>
+        <span>{t("pagination.next")}</span>
         <PiArrowRight aria-hidden="true" />
       </button>
     </nav>

--- a/frontend/src/components/productCard/productCard.spec.tsx
+++ b/frontend/src/components/productCard/productCard.spec.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import i18n from "../../i18n/i18n";
 import { useCart } from "../context/useCart";
 
 import ProductCard from "./productCard";
@@ -11,7 +12,8 @@ vi.mock("../context/useCart", () => ({ useCart: vi.fn() }));
 const addToCart = vi.fn();
 
 describe("ProductCard", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    await i18n.changeLanguage("en");
     vi.mocked(useCart).mockReturnValue({ cart: null, addToCart } as unknown as ReturnType<typeof useCart>);
     addToCart.mockReset();
   });
@@ -58,5 +60,28 @@ describe("ProductCard", () => {
 
     expect(screen.queryByText("A long product description")).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Add to Cart" })).not.toBeInTheDocument();
+  });
+
+  it("localizes actions and currency presentation", async () => {
+    await i18n.changeLanguage("de");
+
+    const { container } = render(
+      <MemoryRouter>
+        <ProductCard
+          currentPrice={7999}
+          id="product-id"
+          imgUrl="/running-shoes.jpg"
+          name="Everyday Running Shoes"
+          oldPrice={9999}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole("link", { name: "Everyday Running Shoes ansehen" })).toHaveAttribute(
+      "href",
+      "/product/product-id"
+    );
+    expect(container.querySelector(".product-card__current-price")?.textContent).toBe("79,99 €");
+    expect(screen.getByRole("button", { name: "In den Warenkorb" })).toBeVisible();
   });
 });

--- a/frontend/src/components/productCard/productCard.tsx
+++ b/frontend/src/components/productCard/productCard.tsx
@@ -1,5 +1,7 @@
+import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 
+import { formatMoney } from "../../utils/formatMoney";
 import Button from "../common/button/button";
 import { useCart } from "../context/useCart";
 
@@ -19,11 +21,6 @@ type ProductCardProps = {
   variant?: ProductCardVariant;
 };
 
-const moneyFormatter = new Intl.NumberFormat("en-IE", {
-  style: "currency",
-  currency: "EUR",
-});
-
 const ProductCard = ({
   id,
   name,
@@ -35,15 +32,17 @@ const ProductCard = ({
   className = "",
   variant = "catalog",
 }: ProductCardProps) => {
+  const { i18n, t } = useTranslation("common");
   const { cart, addToCart } = useCart();
   const productInCart = cart?.items.some((item) => item.productId === id) ?? false;
   const discount = oldPrice > currentPrice ? Math.round(((oldPrice - currentPrice) / oldPrice) * 100) : 0;
   const shortDescription = description.length > 50 ? `${description.slice(0, 47)}...` : description;
   const cardClassName = `product-card product-card--${variant} ${className}`.trim();
+  const language = i18n.resolvedLanguage ?? i18n.language;
 
   return (
     <article className={cardClassName}>
-      <Link aria-label={`View ${name}`} className="product-card__link" to={`/product/${id}`}>
+      <Link aria-label={t("productCard.view", { name })} className="product-card__link" to={`/product/${id}`}>
         <div className="product-card__img-wrapper">
           <img
             alt={altText}
@@ -60,10 +59,10 @@ const ProductCard = ({
           <h3 className="product-card__name">{name}</h3>
           {description && variant === "catalog" && <p className="product-card__description">{shortDescription}</p>}
           <div className="product-card__prices">
-            <span className="product-card__current-price">{moneyFormatter.format(currentPrice / 100)}</span>
+            <span className="product-card__current-price">{formatMoney(currentPrice, language)}</span>
             {discount > 0 && (
               <>
-                <span className="product-card__old-price">{moneyFormatter.format(oldPrice / 100)}</span>
+                <span className="product-card__old-price">{formatMoney(oldPrice, language)}</span>
                 <span className="product-card__discount">-{discount}%</span>
               </>
             )}
@@ -78,7 +77,7 @@ const ProductCard = ({
           onClick={() => {
             if (!productInCart) void addToCart(id);
           }}
-          text={productInCart ? "In Cart" : "Add to Cart"}
+          text={productInCart ? t("productCard.inCart") : t("productCard.addToCart")}
         />
       )}
     </article>

--- a/frontend/src/components/productList/ProductList.spec.tsx
+++ b/frontend/src/components/productList/ProductList.spec.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import i18n from "../../i18n/i18n";
+
+import ProductList from "./ProductList";
+
+vi.mock("../productCard/productCard", () => ({ default: () => <article>Product</article> }));
+
+describe("ProductList", () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage("en");
+  });
+
+  it("localizes its empty state", async () => {
+    await i18n.changeLanguage("ru");
+
+    render(<ProductList products={[]} />);
+
+    expect(screen.getByText("Товары не найдены.")).toBeVisible();
+  });
+});

--- a/frontend/src/components/productList/ProductList.tsx
+++ b/frontend/src/components/productList/ProductList.tsx
@@ -1,6 +1,9 @@
+import { useTranslation } from "react-i18next";
+
+import type { Product } from "../../services/productService/types";
 import Paragraph from "../common/paragraph/paragraph";
 import ProductCard, { type ProductCardVariant } from "../productCard/productCard";
-import type { Product } from "../../services/productService/types";
+
 import "./ProductList.scss";
 
 type ProductListProps = {
@@ -10,8 +13,10 @@ type ProductListProps = {
 };
 
 const ProductList = ({ products, className = "", variant = "catalog" }: ProductListProps) => {
+  const { t } = useTranslation("common");
+
   if (!products.length) {
-    return <Paragraph text="No products found." className="product-list__empty" />;
+    return <Paragraph text={t("productCard.noProducts")} className="product-list__empty" />;
   }
 
   return (

--- a/frontend/src/i18n/locales/de/common.ts
+++ b/frontend/src/i18n/locales/de/common.ts
@@ -150,4 +150,21 @@ export const deCommon = {
     options: "Katalogoptionen",
     closeOptions: "Katalogoptionen schließen",
   },
+  sorting: {
+    label: "Sortieren nach:",
+    control: "Produkte sortieren",
+    relevance: "Höchste Relevanz",
+    priceAscending: "Preis: aufsteigend",
+    priceDescending: "Preis: absteigend",
+    nameAscending: "Name: A bis Z",
+    nameDescending: "Name: Z bis A",
+  },
+  pagination: {
+    navigation: "Katalogseiten",
+    previousPage: "Vorherige Seite",
+    previous: "Zurück",
+    nextPage: "Nächste Seite",
+    next: "Weiter",
+    goToPage: "Zu Seite {{page}} wechseln",
+  },
 } satisfies CommonTranslations;

--- a/frontend/src/i18n/locales/de/common.ts
+++ b/frontend/src/i18n/locales/de/common.ts
@@ -139,4 +139,15 @@ export const deCommon = {
     sessionsDescription:
       "HttpOnly-Cookies, rotierende Refresh-Sitzungen und CSRF-Schutz halten Zugangsdaten vom Frontend-Code fern.",
   },
+  breadcrumbs: {
+    navigation: "Breadcrumb-Navigation",
+    home: "Startseite",
+    catalog: "Katalog",
+  },
+  catalogNavigation: {
+    categories: "Kategorien",
+    allProducts: "Alle Produkte",
+    options: "Katalogoptionen",
+    closeOptions: "Katalogoptionen schließen",
+  },
 } satisfies CommonTranslations;

--- a/frontend/src/i18n/locales/de/common.ts
+++ b/frontend/src/i18n/locales/de/common.ts
@@ -173,4 +173,18 @@ export const deCommon = {
     inCart: "Im Warenkorb",
     noProducts: "Keine Produkte gefunden.",
   },
+  catalog: {
+    title: "Katalog",
+    allProducts: "Alle Produkte",
+    searchResults: "Suchergebnisse für „{{term}}“",
+    loadingProducts: "Produkte werden geladen…",
+    loading: "Katalog wird geladen",
+    openOptions: "Katalogoptionen öffnen",
+    loadError: "Der Katalog konnte nicht geladen werden. Bitte versuche es erneut.",
+    retry: "Erneut versuchen",
+    zeroProducts: "0 Produkte",
+    pageSummary: "{{first}}-{{last}} von {{total}} Produkten",
+    noSearchResults: "Keine Produkte für „{{term}}“ gefunden.",
+    noCategoryProducts: "In dieser Kategorie wurden keine Produkte gefunden.",
+  },
 } satisfies CommonTranslations;

--- a/frontend/src/i18n/locales/de/common.ts
+++ b/frontend/src/i18n/locales/de/common.ts
@@ -167,4 +167,10 @@ export const deCommon = {
     next: "Weiter",
     goToPage: "Zu Seite {{page}} wechseln",
   },
+  productCard: {
+    view: "{{name}} ansehen",
+    addToCart: "In den Warenkorb",
+    inCart: "Im Warenkorb",
+    noProducts: "Keine Produkte gefunden.",
+  },
 } satisfies CommonTranslations;

--- a/frontend/src/i18n/locales/en/common.ts
+++ b/frontend/src/i18n/locales/en/common.ts
@@ -146,6 +146,23 @@ export const enCommon = {
     options: "Catalog options",
     closeOptions: "Close catalog options",
   },
+  sorting: {
+    label: "Sort by:",
+    control: "Sort products",
+    relevance: "Most relevant",
+    priceAscending: "Price: low to high",
+    priceDescending: "Price: high to low",
+    nameAscending: "Name: A to Z",
+    nameDescending: "Name: Z to A",
+  },
+  pagination: {
+    navigation: "Catalog pagination",
+    previousPage: "Previous page",
+    previous: "Previous",
+    nextPage: "Next page",
+    next: "Next",
+    goToPage: "Go to page {{page}}",
+  },
 } as const;
 
 export type CommonTranslations = {

--- a/frontend/src/i18n/locales/en/common.ts
+++ b/frontend/src/i18n/locales/en/common.ts
@@ -135,6 +135,17 @@ export const enCommon = {
     sessionsDescription:
       "HttpOnly cookies, rotating refresh sessions, and CSRF protection keep credentials out of frontend code.",
   },
+  breadcrumbs: {
+    navigation: "Breadcrumb",
+    home: "Home",
+    catalog: "Catalog",
+  },
+  catalogNavigation: {
+    categories: "Categories",
+    allProducts: "All products",
+    options: "Catalog options",
+    closeOptions: "Close catalog options",
+  },
 } as const;
 
 export type CommonTranslations = {

--- a/frontend/src/i18n/locales/en/common.ts
+++ b/frontend/src/i18n/locales/en/common.ts
@@ -169,6 +169,20 @@ export const enCommon = {
     inCart: "In Cart",
     noProducts: "No products found.",
   },
+  catalog: {
+    title: "Catalog",
+    allProducts: "All products",
+    searchResults: "Search results for “{{term}}”",
+    loadingProducts: "Loading products…",
+    loading: "Catalog loading",
+    openOptions: "Open catalog options",
+    loadError: "Unable to load the catalog. Please try again.",
+    retry: "Try again",
+    zeroProducts: "0 products",
+    pageSummary: "Showing {{first}}-{{last}} of {{total}} products",
+    noSearchResults: "No products found for “{{term}}”.",
+    noCategoryProducts: "No products found in this category.",
+  },
 } as const;
 
 export type CommonTranslations = {

--- a/frontend/src/i18n/locales/en/common.ts
+++ b/frontend/src/i18n/locales/en/common.ts
@@ -163,6 +163,12 @@ export const enCommon = {
     next: "Next",
     goToPage: "Go to page {{page}}",
   },
+  productCard: {
+    view: "View {{name}}",
+    addToCart: "Add to Cart",
+    inCart: "In Cart",
+    noProducts: "No products found.",
+  },
 } as const;
 
 export type CommonTranslations = {

--- a/frontend/src/i18n/locales/ru/common.ts
+++ b/frontend/src/i18n/locales/ru/common.ts
@@ -169,4 +169,18 @@ export const ruCommon = {
     inCart: "В корзине",
     noProducts: "Товары не найдены.",
   },
+  catalog: {
+    title: "Каталог",
+    allProducts: "Все товары",
+    searchResults: "Результаты поиска по запросу «{{term}}»",
+    loadingProducts: "Загружаем товары…",
+    loading: "Загрузка каталога",
+    openOptions: "Открыть параметры каталога",
+    loadError: "Не удалось загрузить каталог. Попробуйте ещё раз.",
+    retry: "Попробовать снова",
+    zeroProducts: "0 товаров",
+    pageSummary: "Показано {{first}}-{{last}} из {{total}} товаров",
+    noSearchResults: "По запросу «{{term}}» товары не найдены.",
+    noCategoryProducts: "В этой категории товары не найдены.",
+  },
 } satisfies CommonTranslations;

--- a/frontend/src/i18n/locales/ru/common.ts
+++ b/frontend/src/i18n/locales/ru/common.ts
@@ -146,4 +146,21 @@ export const ruCommon = {
     options: "Параметры каталога",
     closeOptions: "Закрыть параметры каталога",
   },
+  sorting: {
+    label: "Сортировать:",
+    control: "Сортировка товаров",
+    relevance: "По релевантности",
+    priceAscending: "Цена: по возрастанию",
+    priceDescending: "Цена: по убыванию",
+    nameAscending: "Название: от А до Я",
+    nameDescending: "Название: от Я до А",
+  },
+  pagination: {
+    navigation: "Страницы каталога",
+    previousPage: "Предыдущая страница",
+    previous: "Назад",
+    nextPage: "Следующая страница",
+    next: "Вперёд",
+    goToPage: "Перейти на страницу {{page}}",
+  },
 } satisfies CommonTranslations;

--- a/frontend/src/i18n/locales/ru/common.ts
+++ b/frontend/src/i18n/locales/ru/common.ts
@@ -135,4 +135,15 @@ export const ruCommon = {
     sessionsDescription:
       "HttpOnly cookies, ротация refresh-сессий и CSRF-защита не допускают попадания данных авторизации во frontend-код.",
   },
+  breadcrumbs: {
+    navigation: "Навигационная цепочка",
+    home: "Главная",
+    catalog: "Каталог",
+  },
+  catalogNavigation: {
+    categories: "Категории",
+    allProducts: "Все товары",
+    options: "Параметры каталога",
+    closeOptions: "Закрыть параметры каталога",
+  },
 } satisfies CommonTranslations;

--- a/frontend/src/i18n/locales/ru/common.ts
+++ b/frontend/src/i18n/locales/ru/common.ts
@@ -163,4 +163,10 @@ export const ruCommon = {
     next: "Вперёд",
     goToPage: "Перейти на страницу {{page}}",
   },
+  productCard: {
+    view: "Открыть {{name}}",
+    addToCart: "Добавить в корзину",
+    inCart: "В корзине",
+    noProducts: "Товары не найдены.",
+  },
 } satisfies CommonTranslations;

--- a/frontend/src/pages/Category/Category.spec.tsx
+++ b/frontend/src/pages/Category/Category.spec.tsx
@@ -1,7 +1,8 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import i18n from "../../i18n/i18n";
 import { fetchChildCategories } from "../../services/categoryService/categoryService";
 import { fetchProductPage } from "../../services/productService/productService";
 import type { Product } from "../../services/productService/types";
@@ -63,7 +64,8 @@ function renderCatalog(initialEntry = "/catalog") {
 }
 
 describe("CategoryPage", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    await i18n.changeLanguage("en");
     vi.mocked(fetchChildCategories).mockReset();
     vi.mocked(fetchProductPage).mockReset();
     vi.mocked(fetchChildCategories).mockResolvedValue([{ id: "balls", name: "Balls", slug: "balls", parentId: null }]);
@@ -129,5 +131,30 @@ describe("CategoryPage", () => {
 
     expect(screen.getByRole("dialog", { name: "Catalog options" })).toBeVisible();
     expect(screen.getAllByRole("link", { name: "Balls" })).toHaveLength(2);
+  });
+
+  it("localizes catalog summaries and controls", async () => {
+    await i18n.changeLanguage("ru");
+    renderCatalog();
+
+    expect(await screen.findByText("Показано 1-6 из 8 товаров")).toBeVisible();
+    expect(screen.getByRole("heading", { level: 1, name: "Все товары" })).toBeVisible();
+    expect(screen.getByRole("combobox", { name: "Сортировка товаров" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Открыть параметры каталога" })).toBeVisible();
+  });
+
+  it("updates an existing load error when the language changes", async () => {
+    vi.mocked(fetchProductPage).mockRejectedValue(new Error("Unavailable"));
+    renderCatalog();
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Unable to load the catalog");
+
+    await act(async () => {
+      await i18n.changeLanguage("de");
+    });
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Der Katalog konnte nicht geladen werden");
+    expect(screen.getByRole("button", { name: "Erneut versuchen" })).toBeVisible();
+    expect(fetchProductPage).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/pages/Category/Category.tsx
+++ b/frontend/src/pages/Category/Category.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { PiSlidersHorizontal } from "react-icons/pi";
+import { useTranslation } from "react-i18next";
 import { useLocation, useSearchParams } from "react-router-dom";
 
 import Breadcrumbs, { type Crumb } from "../../components/Breadcrumbs/Breadcrumbs";
@@ -50,14 +51,15 @@ function categoryPath(parentSegments: string[], slug: string): string {
   return ["", "catalog", ...parentSegments, slug].join("/");
 }
 
-function pageSummary(page: ProductPage): string {
-  if (!page.total) return "0 products";
+function pageRange(page: ProductPage): { first: number; last: number; total: number } | null {
+  if (!page.total) return null;
   const firstItem = page.offset + 1;
   const lastItem = Math.min(page.offset + page.items.length, page.total);
-  return `Showing ${firstItem}-${lastItem} of ${page.total} products`;
+  return { first: firstItem, last: lastItem, total: page.total };
 }
 
 export default function CategoryPage() {
+  const { t } = useTranslation("common");
   const location = useLocation();
   const [searchParams, setSearchParams] = useSearchParams();
 
@@ -66,7 +68,7 @@ export default function CategoryPage() {
   const [currentCategory, setCurrentCategory] = useState<Category | null>(null);
   const [productPage, setProductPage] = useState<ProductPage>(EMPTY_PAGE);
   const [resolvedRequestKey, setResolvedRequestKey] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const [hasError, setHasError] = useState(false);
   const [categoryNotFound, setCategoryNotFound] = useState(false);
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const [reloadKey, setReloadKey] = useState(0);
@@ -83,7 +85,7 @@ export default function CategoryPage() {
     let cancelled = false;
 
     const loadCatalog = async () => {
-      setError(null);
+      setHasError(false);
       setCategoryNotFound(false);
 
       try {
@@ -138,7 +140,7 @@ export default function CategoryPage() {
       } catch (loadError) {
         if (cancelled) return;
         if (loadError instanceof CategoryNotFoundError) setCategoryNotFound(true);
-        else setError(loadError instanceof Error ? loadError.message : "Unable to load the catalog.");
+        else setHasError(true);
       } finally {
         if (!cancelled) setResolvedRequestKey(requestKey);
       }
@@ -169,12 +171,13 @@ export default function CategoryPage() {
   if (!isLoading && categoryNotFound) return <NotFoundPage />;
 
   const title = searchTerm
-    ? `Search results for “${searchTerm}”`
+    ? t("catalog.searchResults", { term: searchTerm })
     : isLoading
-      ? "Catalog"
-      : (currentCategory?.name ?? "All products");
+      ? t("catalog.title")
+      : (currentCategory?.name ?? t("catalog.allProducts"));
   const visibleBreadcrumbs = isLoading ? [] : breadcrumbs;
   const visibleCategoryItems = isLoading ? [] : categoryItems;
+  const visibleRange = pageRange(productPage);
 
   return (
     <PageContainer className="category-page">
@@ -189,14 +192,20 @@ export default function CategoryPage() {
           <header className="category-page__toolbar">
             <div className="category-page__heading">
               <h1 id="catalog-title">{title}</h1>
-              <p>{isLoading ? "Loading products…" : pageSummary(productPage)}</p>
+              <p>
+                {isLoading
+                  ? t("catalog.loadingProducts")
+                  : visibleRange
+                    ? t("catalog.pageSummary", visibleRange)
+                    : t("catalog.zeroProducts")}
+              </p>
             </div>
 
             <Sorting className="category-page__desktop-sort" currentSort={currentSort} onSortChange={updateSort} />
             <button
               aria-controls="catalog-options"
               aria-expanded={isDrawerOpen}
-              aria-label="Open catalog options"
+              aria-label={t("catalog.openOptions")}
               className="category-page__filter-toggle"
               onClick={() => setIsDrawerOpen(true)}
               type="button"
@@ -206,15 +215,15 @@ export default function CategoryPage() {
           </header>
 
           {isLoading ? (
-            <div aria-label="Catalog loading" aria-live="polite" className="category-page__status" role="status">
+            <div aria-label={t("catalog.loading")} aria-live="polite" className="category-page__status" role="status">
               <span className="category-page__spinner" />
-              Loading products…
+              {t("catalog.loadingProducts")}
             </div>
-          ) : error ? (
+          ) : hasError ? (
             <div className="category-page__status" role="alert">
-              <p>{error}</p>
+              <p>{t("catalog.loadError")}</p>
               <button className="category-page__retry" onClick={() => setReloadKey((key) => key + 1)} type="button">
-                Try again
+                {t("catalog.retry")}
               </button>
             </div>
           ) : productPage.items.length ? (
@@ -230,7 +239,7 @@ export default function CategoryPage() {
             </>
           ) : (
             <div className="category-page__status">
-              <p>{searchTerm ? `No products found for “${searchTerm}”.` : "No products found in this category."}</p>
+              <p>{searchTerm ? t("catalog.noSearchResults", { term: searchTerm }) : t("catalog.noCategoryProducts")}</p>
             </div>
           )}
         </main>

--- a/frontend/src/utils/formatMoney.spec.ts
+++ b/frontend/src/utils/formatMoney.spec.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+import { formatMoney } from "./formatMoney";
+
+describe("formatMoney", () => {
+  it("formats minor units using the selected supported locale", () => {
+    expect(formatMoney(7999, "en")).toBe("€79.99");
+    expect(formatMoney(7999, "de")).toBe("79,99 €");
+    expect(formatMoney(7999, "ru")).toBe("79,99 €");
+  });
+
+  it("normalizes regional language tags and falls back to English", () => {
+    expect(formatMoney(123456, "de-AT")).toBe("1.234,56 €");
+    expect(formatMoney(123456, "fr-FR")).toBe("€1,234.56");
+  });
+});

--- a/frontend/src/utils/formatMoney.ts
+++ b/frontend/src/utils/formatMoney.ts
@@ -1,0 +1,16 @@
+import { DEFAULT_LANGUAGE, normalizeLanguage, type SupportedLanguage } from "../i18n/languages";
+
+const MONEY_LOCALES: Record<SupportedLanguage, string> = {
+  en: "en-IE",
+  de: "de-DE",
+  ru: "ru-RU",
+};
+
+export function formatMoney(amount: number, language?: string): string {
+  const supportedLanguage = normalizeLanguage(language) ?? DEFAULT_LANGUAGE;
+
+  return new Intl.NumberFormat(MONEY_LOCALES[supportedLanguage], {
+    style: "currency",
+    currency: "EUR",
+  }).format(amount / 100);
+}


### PR DESCRIPTION
## Summary

- localize catalog breadcrumbs, category navigation, sorting, pagination, and mobile filter drawer
- localize product-card actions and empty-list feedback
- add a reusable locale-aware EUR formatter for English, German, and Russian
- localize catalog loading, error, search, summary, retry, and empty states
- keep URL/API sort values stable while translating their user-facing labels
- add unit and Playwright coverage for localized desktop and mobile catalog flows

## Why

The storefront shell and Home page support English, German, and Russian, but the catalog interface still contained hardcoded English copy and always formatted prices with the English locale. This PR makes the catalog UI react consistently to language changes without changing routing or backend query contracts.

## Scope note

Product and category names/descriptions remain catalog data returned by the API. Localized catalog content requires a separate backend data-model and content migration; this PR intentionally localizes the interface around that data.
