### PR TITLE
feat(frontend): localize the product experience

### DIFF
--- a/e2e/store.spec.ts
+++ b/e2e/store.spec.ts
@@ -95,6 +95,38 @@ test("localizes catalog controls across desktop and mobile layouts", async ({ pa
   await expect(drawer).toHaveCount(0);
 });
 
+test("localizes product purchase and gallery controls", async ({ page }) => {
+  await page.goto("/catalog");
+
+  await page.getByRole("button", { name: "Current language: English" }).click();
+  await page.getByRole("menuitemradio", { name: "DE Deutsch" }).click();
+  await page.getByRole("link", { name: "Control Tennis Racket ansehen" }).click();
+
+  await expect(page.getByRole("heading", { level: 1, name: "Control Tennis Racket" })).toBeVisible();
+  await expect(page.getByRole("navigation", { name: "Breadcrumb-Navigation" })).toContainText("StartseiteKatalog");
+  await expect(page.getByRole("region", { name: "Bilder von Control Tennis Racket" })).toBeVisible();
+  await expect(page.getByLabel("Produktpreis")).toContainText("89,99 €");
+  await expect(page.getByLabel(/Vorheriger Preis 109,99\s€/)).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Das könnte dir auch gefallen" })).toBeVisible();
+
+  await page.getByRole("button", { name: "Menge erhöhen" }).click();
+  await page.getByRole("button", { name: "In den Warenkorb" }).click();
+  await expect(page.getByText("2 × Control Tennis Racket zum Warenkorb hinzugefügt.")).toBeVisible();
+
+  await page.getByRole("button", { name: "Aktuelle Sprache: Deutsch" }).click();
+  await page.getByRole("menuitemradio", { name: "RU Русский" }).click();
+  await page.setViewportSize({ width: 390, height: 844 });
+
+  await expect(page.getByLabel("Цена товара")).toContainText("89,99 €");
+  await expect(page.getByRole("group", { name: "Количество товара" })).toBeVisible();
+  await page.getByRole("button", { name: "Увеличить Control Tennis Racket, изображение 1 из 1" }).click();
+
+  const galleryDialog = page.getByRole("dialog", { name: "Увеличенное изображение Control Tennis Racket" });
+  await expect(galleryDialog).toBeVisible();
+  await galleryDialog.getByRole("button", { name: "Закрыть увеличенное изображение" }).click();
+  await expect(galleryDialog).toHaveCount(0);
+});
+
 test("registers, shops with a promo code, opens profile and logs out", async ({ page }) => {
   const email = `playwright-${Date.now()}@example.com`;
 

--- a/frontend/src/components/Product/ProductGallery/ProductGallery.spec.tsx
+++ b/frontend/src/components/Product/ProductGallery/ProductGallery.spec.tsx
@@ -1,9 +1,15 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import i18n from "../../../i18n/i18n";
 
 import { ProductGallery } from "./ProductGallery";
 
 describe("ProductGallery", () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage("en");
+  });
+
   it("changes the active image from an accessible thumbnail", () => {
     render(<ProductGallery images={["front.jpg", "back.jpg"]} productName="Training shirt" />);
 
@@ -22,6 +28,20 @@ describe("ProductGallery", () => {
     expect(screen.getByRole("dialog", { name: "Training shirt enlarged image" })).toBeVisible();
 
     fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("localizes gallery and dialog controls", async () => {
+    await i18n.changeLanguage("de");
+    render(<ProductGallery images={["front.jpg", "back.jpg"]} productName="Training shirt" />);
+
+    expect(screen.getByRole("region", { name: "Bilder von Training shirt" })).toBeVisible();
+    fireEvent.click(screen.getByRole("button", { name: "Bild 2 von Training shirt anzeigen" }));
+    expect(screen.getByRole("img", { name: "Training shirt, Bild 2 von 2" })).toHaveAttribute("src", "back.jpg");
+
+    fireEvent.click(screen.getByRole("button", { name: "Training shirt, Bild 2 von 2 vergrößern" }));
+    expect(screen.getByRole("dialog", { name: "Vergrößertes Bild von Training shirt" })).toBeVisible();
+    fireEvent.click(screen.getByRole("button", { name: "Vergrößertes Bild schließen" }));
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/Product/ProductGallery/ProductGallery.tsx
+++ b/frontend/src/components/Product/ProductGallery/ProductGallery.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { PiX } from "react-icons/pi";
+import { useTranslation } from "react-i18next";
 
 import "./ProductGallery.scss";
 
@@ -11,6 +12,7 @@ type ProductGalleryProps = {
 const FALLBACK_IMAGE = "/images/loading.gif";
 
 export function ProductGallery({ images, productName }: ProductGalleryProps) {
+  const { t } = useTranslation("common");
   const galleryImages = images.length ? images : [FALLBACK_IMAGE];
   const [activeIndex, setActiveIndex] = useState(0);
   const [isExpanded, setIsExpanded] = useState(false);
@@ -36,16 +38,20 @@ export function ProductGallery({ images, productName }: ProductGalleryProps) {
   }, [isExpanded]);
 
   const activeImage = galleryImages[activeIndex] ?? galleryImages[0];
-  const imageLabel = `${productName}, image ${activeIndex + 1} of ${galleryImages.length}`;
+  const imageLabel = t("productGallery.image", {
+    name: productName,
+    current: activeIndex + 1,
+    total: galleryImages.length,
+  });
   const galleryClassName = `product-gallery${galleryImages.length === 1 ? " product-gallery--single" : ""}`;
 
   return (
-    <section aria-label={`${productName} images`} className={galleryClassName}>
+    <section aria-label={t("productGallery.region", { name: productName })} className={galleryClassName}>
       {galleryImages.length > 1 && (
         <div className="product-gallery__thumbnails">
           {galleryImages.map((image, index) => (
             <button
-              aria-label={`View ${productName} image ${index + 1}`}
+              aria-label={t("productGallery.viewImage", { name: productName, index: index + 1 })}
               aria-pressed={activeIndex === index}
               className="product-gallery__thumbnail"
               key={`${image}-${index}`}
@@ -59,7 +65,11 @@ export function ProductGallery({ images, productName }: ProductGalleryProps) {
       )}
 
       <button
-        aria-label={`Expand ${imageLabel}`}
+        aria-label={t("productGallery.expand", {
+          name: productName,
+          current: activeIndex + 1,
+          total: galleryImages.length,
+        })}
         className="product-gallery__main"
         onClick={() => setIsExpanded(true)}
         type="button"
@@ -75,7 +85,7 @@ export function ProductGallery({ images, productName }: ProductGalleryProps) {
 
       {isExpanded && (
         <div
-          aria-label={`${productName} enlarged image`}
+          aria-label={t("productGallery.dialog", { name: productName })}
           aria-modal="true"
           className="product-gallery__dialog"
           onClick={(event) => {
@@ -85,7 +95,7 @@ export function ProductGallery({ images, productName }: ProductGalleryProps) {
         >
           <div className="product-gallery__dialog-content">
             <button
-              aria-label="Close enlarged image"
+              aria-label={t("productGallery.close")}
               className="product-gallery__close"
               onClick={() => setIsExpanded(false)}
               type="button"

--- a/frontend/src/components/Product/ProductPurchasePanel/ProductPurchasePanel.spec.tsx
+++ b/frontend/src/components/Product/ProductPurchasePanel/ProductPurchasePanel.spec.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import i18n from "../../../i18n/i18n";
 import type { Product } from "../../../services/productService/types";
 import { useCart } from "../../context/useCart";
 import { ProductPurchasePanel } from "./ProductPurchasePanel";
@@ -21,7 +22,8 @@ const product: Product = {
 describe("ProductPurchasePanel", () => {
   const addToCart = vi.fn();
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    await i18n.changeLanguage("en");
     addToCart.mockReset();
     addToCart.mockResolvedValue(undefined);
     vi.mocked(useCart).mockReturnValue({ addToCart } as never);
@@ -50,5 +52,18 @@ describe("ProductPurchasePanel", () => {
 
     expect(await screen.findByRole("alert")).toHaveTextContent("couldn't add this product");
     expect(screen.getByRole("status", { name: "Quantity" })).toHaveTextContent("2");
+  });
+
+  it("localizes prices, actions, and successful feedback", async () => {
+    await i18n.changeLanguage("de");
+    render(<ProductPurchasePanel product={product} />);
+
+    expect(screen.getByLabelText("Produktpreis")).toHaveTextContent("34,99 €");
+    expect(screen.getByLabelText("Vorheriger Preis 44,99 €")).toBeVisible();
+
+    fireEvent.click(screen.getByRole("button", { name: "Menge erhöhen" }));
+    fireEvent.click(screen.getByRole("button", { name: "In den Warenkorb" }));
+
+    expect(await screen.findByText("2 × Match Football zum Warenkorb hinzugefügt.")).toBeVisible();
   });
 });

--- a/frontend/src/components/Product/ProductPurchasePanel/ProductPurchasePanel.tsx
+++ b/frontend/src/components/Product/ProductPurchasePanel/ProductPurchasePanel.tsx
@@ -1,6 +1,8 @@
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 
 import type { Product } from "../../../services/productService/types";
+import { formatMoney } from "../../../utils/formatMoney";
 import Button from "../../common/button/button";
 import Message from "../../common/message/Message";
 import { useCart } from "../../context/useCart";
@@ -12,19 +14,25 @@ type ProductPurchasePanelProps = {
   product: Product;
 };
 
-const moneyFormatter = new Intl.NumberFormat("en-IE", {
-  style: "currency",
-  currency: "EUR",
-});
+type PurchaseFeedback = { variant: "error" } | { variant: "success"; quantity: number; productName: string };
 
 export function ProductPurchasePanel({ product }: ProductPurchasePanelProps) {
+  const { i18n, t } = useTranslation("common");
   const { addToCart } = useCart();
   const [quantity, setQuantity] = useState(1);
   const [isAdding, setIsAdding] = useState(false);
-  const [feedback, setFeedback] = useState<{ text: string; variant: "error" | "success" } | null>(null);
+  const [feedback, setFeedback] = useState<PurchaseFeedback | null>(null);
 
   const hasDiscount = product.oldPrice > product.currentPrice;
   const discount = hasDiscount ? Math.round(((product.oldPrice - product.currentPrice) / product.oldPrice) * 100) : 0;
+  const language = i18n.resolvedLanguage ?? i18n.language;
+  const currentPrice = formatMoney(product.currentPrice, language);
+  const oldPrice = formatMoney(product.oldPrice, language);
+  const feedbackText = feedback
+    ? feedback.variant === "success"
+      ? t("productPurchase.added", { quantity: feedback.quantity, name: feedback.productName })
+      : t("productPurchase.addError")
+    : null;
 
   const addProduct = async () => {
     setIsAdding(true);
@@ -32,12 +40,13 @@ export function ProductPurchasePanel({ product }: ProductPurchasePanelProps) {
     try {
       await addToCart(product.id, quantity);
       setFeedback({
-        text: `${quantity} × ${product.name} added to your cart.`,
         variant: "success",
+        quantity,
+        productName: product.name,
       });
       setQuantity(1);
     } catch {
-      setFeedback({ text: "We couldn't add this product. Please try again.", variant: "error" });
+      setFeedback({ variant: "error" });
     } finally {
       setIsAdding(false);
     }
@@ -47,17 +56,15 @@ export function ProductPurchasePanel({ product }: ProductPurchasePanelProps) {
     <section aria-labelledby="product-title" className="product-purchase-panel">
       <h1 id="product-title">{product.name}</h1>
 
-      <div aria-label="Product price" className="product-purchase-panel__prices">
-        <span className="product-purchase-panel__current-price">
-          {moneyFormatter.format(product.currentPrice / 100)}
-        </span>
+      <div aria-label={t("productPurchase.price")} className="product-purchase-panel__prices">
+        <span className="product-purchase-panel__current-price">{currentPrice}</span>
         {hasDiscount && (
           <>
             <span
-              aria-label={`Previous price ${moneyFormatter.format(product.oldPrice / 100)}`}
+              aria-label={t("productPurchase.previousPrice", { price: oldPrice })}
               className="product-purchase-panel__old-price"
             >
-              {moneyFormatter.format(product.oldPrice / 100)}
+              {oldPrice}
             </span>
             <span className="product-purchase-panel__discount">-{discount}%</span>
           </>
@@ -65,7 +72,7 @@ export function ProductPurchasePanel({ product }: ProductPurchasePanelProps) {
       </div>
 
       <p className="product-purchase-panel__description">
-        {product.description || "Product details will be available soon."}
+        {product.description || t("productPurchase.detailsUnavailable")}
       </p>
 
       <div className="product-purchase-panel__actions">
@@ -74,11 +81,13 @@ export function ProductPurchasePanel({ product }: ProductPurchasePanelProps) {
           className="product-purchase-panel__add"
           disabled={isAdding}
           onClick={() => void addProduct()}
-          text={isAdding ? "Adding…" : "Add to Cart"}
+          text={isAdding ? t("productPurchase.adding") : t("productPurchase.addToCart")}
         />
       </div>
 
-      {feedback && <Message onClose={() => setFeedback(null)} text={feedback.text} variant={feedback.variant} />}
+      {feedback && feedbackText && (
+        <Message onClose={() => setFeedback(null)} text={feedbackText} variant={feedback.variant} />
+      )}
     </section>
   );
 }

--- a/frontend/src/components/Product/QuantitySelector/QuantitySelector.spec.tsx
+++ b/frontend/src/components/Product/QuantitySelector/QuantitySelector.spec.tsx
@@ -1,9 +1,15 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import i18n from "../../../i18n/i18n";
 
 import { QuantitySelector } from "./QuantitySelector";
 
 describe("QuantitySelector", () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage("en");
+  });
+
   it("requests quantity changes within its limits", () => {
     const onChange = vi.fn();
     const { rerender } = render(<QuantitySelector onChange={onChange} value={2} />);
@@ -23,5 +29,17 @@ describe("QuantitySelector", () => {
 
     expect(screen.getByRole("button", { name: "Decrease quantity" })).toBeDisabled();
     expect(screen.getByRole("status", { name: "Quantity" })).toHaveTextContent("1");
+  });
+
+  it("localizes the group and quantity actions", async () => {
+    await i18n.changeLanguage("ru");
+    const onChange = vi.fn();
+
+    render(<QuantitySelector onChange={onChange} value={2} />);
+
+    expect(screen.getByRole("group", { name: "Количество товара" })).toBeVisible();
+    fireEvent.click(screen.getByRole("button", { name: "Увеличить количество" }));
+    expect(onChange).toHaveBeenCalledWith(3);
+    expect(screen.getByRole("status", { name: "Количество" })).toHaveTextContent("2");
   });
 });

--- a/frontend/src/components/Product/QuantitySelector/QuantitySelector.tsx
+++ b/frontend/src/components/Product/QuantitySelector/QuantitySelector.tsx
@@ -1,4 +1,5 @@
 import { PiMinus, PiPlus } from "react-icons/pi";
+import { useTranslation } from "react-i18next";
 
 import "./QuantitySelector.scss";
 
@@ -19,23 +20,24 @@ export function QuantitySelector({
   disabled = false,
   className = "",
 }: QuantitySelectorProps) {
+  const { t } = useTranslation("common");
   const selectorClassName = `quantity-selector ${className}`.trim();
 
   return (
-    <div aria-label="Product quantity" className={selectorClassName} role="group">
+    <div aria-label={t("quantity.region")} className={selectorClassName} role="group">
       <button
-        aria-label="Decrease quantity"
+        aria-label={t("quantity.decrease")}
         disabled={disabled || value <= min}
         onClick={() => onChange(Math.max(min, value - 1))}
         type="button"
       >
         <PiMinus aria-hidden="true" />
       </button>
-      <output aria-live="polite" aria-label="Quantity">
+      <output aria-live="polite" aria-label={t("quantity.value")}>
         {value}
       </output>
       <button
-        aria-label="Increase quantity"
+        aria-label={t("quantity.increase")}
         disabled={disabled || value >= max}
         onClick={() => onChange(Math.min(max, value + 1))}
         type="button"

--- a/frontend/src/components/Product/RelatedProducts/RelatedProducts.spec.tsx
+++ b/frontend/src/components/Product/RelatedProducts/RelatedProducts.spec.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import i18n from "../../../i18n/i18n";
 import type { Product } from "../../../services/productService/types";
 import { RelatedProducts } from "./RelatedProducts";
 
@@ -27,6 +28,10 @@ function product(index: number): Product {
 }
 
 describe("RelatedProducts", () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage("en");
+  });
+
   it("excludes the current product and limits the storefront row to four items", () => {
     render(
       <RelatedProducts currentProductId="product-1" products={Array.from({ length: 6 }, (_, i) => product(i + 1))} />
@@ -42,5 +47,13 @@ describe("RelatedProducts", () => {
     const { container } = render(<RelatedProducts currentProductId="product-1" products={[product(1)]} />);
 
     expect(container).toBeEmptyDOMElement();
+  });
+
+  it("localizes the recommendations heading", async () => {
+    await i18n.changeLanguage("ru");
+
+    render(<RelatedProducts currentProductId="product-1" products={[product(1), product(2)]} />);
+
+    expect(screen.getByRole("heading", { name: "Вам также может понравиться" })).toBeVisible();
   });
 });

--- a/frontend/src/components/Product/RelatedProducts/RelatedProducts.tsx
+++ b/frontend/src/components/Product/RelatedProducts/RelatedProducts.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from "react-i18next";
+
 import type { Product } from "../../../services/productService/types";
 import ProductList from "../../productList/ProductList";
 
@@ -9,12 +11,13 @@ type RelatedProductsProps = {
 };
 
 export function RelatedProducts({ currentProductId, products }: RelatedProductsProps) {
+  const { t } = useTranslation("common");
   const relatedProducts = products.filter((product) => product.id !== currentProductId).slice(0, 4);
   if (!relatedProducts.length) return null;
 
   return (
     <section aria-labelledby="related-products-title" className="related-products">
-      <h2 id="related-products-title">You might also like</h2>
+      <h2 id="related-products-title">{t("relatedProducts.heading")}</h2>
       <ProductList className="related-products__list" products={relatedProducts} variant="showcase" />
     </section>
   );

--- a/frontend/src/i18n/locales/de/common.ts
+++ b/frontend/src/i18n/locales/de/common.ts
@@ -201,4 +201,13 @@ export const deCommon = {
     value: "Menge",
     increase: "Menge erhöhen",
   },
+  productPurchase: {
+    price: "Produktpreis",
+    previousPrice: "Vorheriger Preis {{price}}",
+    detailsUnavailable: "Produktdetails sind bald verfügbar.",
+    adding: "Wird hinzugefügt…",
+    addToCart: "In den Warenkorb",
+    added: "{{quantity}} × {{name}} zum Warenkorb hinzugefügt.",
+    addError: "Dieses Produkt konnte nicht hinzugefügt werden. Bitte versuche es erneut.",
+  },
 } satisfies CommonTranslations;

--- a/frontend/src/i18n/locales/de/common.ts
+++ b/frontend/src/i18n/locales/de/common.ts
@@ -213,4 +213,10 @@ export const deCommon = {
   relatedProducts: {
     heading: "Das könnte dir auch gefallen",
   },
+  productPage: {
+    loading: "Produkt wird geladen",
+    loadingProduct: "Produkt wird geladen…",
+    loadError: "Dieses Produkt konnte nicht geladen werden. Bitte versuche es erneut.",
+    retry: "Erneut versuchen",
+  },
 } satisfies CommonTranslations;

--- a/frontend/src/i18n/locales/de/common.ts
+++ b/frontend/src/i18n/locales/de/common.ts
@@ -210,4 +210,7 @@ export const deCommon = {
     added: "{{quantity}} × {{name}} zum Warenkorb hinzugefügt.",
     addError: "Dieses Produkt konnte nicht hinzugefügt werden. Bitte versuche es erneut.",
   },
+  relatedProducts: {
+    heading: "Das könnte dir auch gefallen",
+  },
 } satisfies CommonTranslations;

--- a/frontend/src/i18n/locales/de/common.ts
+++ b/frontend/src/i18n/locales/de/common.ts
@@ -187,4 +187,12 @@ export const deCommon = {
     noSearchResults: "Keine Produkte für „{{term}}“ gefunden.",
     noCategoryProducts: "In dieser Kategorie wurden keine Produkte gefunden.",
   },
+  productGallery: {
+    region: "Bilder von {{name}}",
+    image: "{{name}}, Bild {{current}} von {{total}}",
+    viewImage: "Bild {{index}} von {{name}} anzeigen",
+    expand: "{{name}}, Bild {{current}} von {{total}} vergrößern",
+    dialog: "Vergrößertes Bild von {{name}}",
+    close: "Vergrößertes Bild schließen",
+  },
 } satisfies CommonTranslations;

--- a/frontend/src/i18n/locales/de/common.ts
+++ b/frontend/src/i18n/locales/de/common.ts
@@ -195,4 +195,10 @@ export const deCommon = {
     dialog: "Vergrößertes Bild von {{name}}",
     close: "Vergrößertes Bild schließen",
   },
+  quantity: {
+    region: "Produktmenge",
+    decrease: "Menge verringern",
+    value: "Menge",
+    increase: "Menge erhöhen",
+  },
 } satisfies CommonTranslations;

--- a/frontend/src/i18n/locales/en/common.ts
+++ b/frontend/src/i18n/locales/en/common.ts
@@ -191,6 +191,12 @@ export const enCommon = {
     dialog: "{{name}} enlarged image",
     close: "Close enlarged image",
   },
+  quantity: {
+    region: "Product quantity",
+    decrease: "Decrease quantity",
+    value: "Quantity",
+    increase: "Increase quantity",
+  },
 } as const;
 
 export type CommonTranslations = {

--- a/frontend/src/i18n/locales/en/common.ts
+++ b/frontend/src/i18n/locales/en/common.ts
@@ -206,6 +206,9 @@ export const enCommon = {
     added: "{{quantity}} × {{name}} added to your cart.",
     addError: "We couldn't add this product. Please try again.",
   },
+  relatedProducts: {
+    heading: "You might also like",
+  },
 } as const;
 
 export type CommonTranslations = {

--- a/frontend/src/i18n/locales/en/common.ts
+++ b/frontend/src/i18n/locales/en/common.ts
@@ -209,6 +209,12 @@ export const enCommon = {
   relatedProducts: {
     heading: "You might also like",
   },
+  productPage: {
+    loading: "Product loading",
+    loadingProduct: "Loading product…",
+    loadError: "We couldn't load this product. Please try again.",
+    retry: "Try again",
+  },
 } as const;
 
 export type CommonTranslations = {

--- a/frontend/src/i18n/locales/en/common.ts
+++ b/frontend/src/i18n/locales/en/common.ts
@@ -183,6 +183,14 @@ export const enCommon = {
     noSearchResults: "No products found for “{{term}}”.",
     noCategoryProducts: "No products found in this category.",
   },
+  productGallery: {
+    region: "{{name}} images",
+    image: "{{name}}, image {{current}} of {{total}}",
+    viewImage: "View {{name}} image {{index}}",
+    expand: "Expand {{name}}, image {{current}} of {{total}}",
+    dialog: "{{name}} enlarged image",
+    close: "Close enlarged image",
+  },
 } as const;
 
 export type CommonTranslations = {

--- a/frontend/src/i18n/locales/en/common.ts
+++ b/frontend/src/i18n/locales/en/common.ts
@@ -197,6 +197,15 @@ export const enCommon = {
     value: "Quantity",
     increase: "Increase quantity",
   },
+  productPurchase: {
+    price: "Product price",
+    previousPrice: "Previous price {{price}}",
+    detailsUnavailable: "Product details will be available soon.",
+    adding: "Adding…",
+    addToCart: "Add to Cart",
+    added: "{{quantity}} × {{name}} added to your cart.",
+    addError: "We couldn't add this product. Please try again.",
+  },
 } as const;
 
 export type CommonTranslations = {

--- a/frontend/src/i18n/locales/ru/common.ts
+++ b/frontend/src/i18n/locales/ru/common.ts
@@ -206,4 +206,7 @@ export const ruCommon = {
     added: "{{quantity}} × {{name}} добавлено в корзину.",
     addError: "Не удалось добавить товар. Попробуйте ещё раз.",
   },
+  relatedProducts: {
+    heading: "Вам также может понравиться",
+  },
 } satisfies CommonTranslations;

--- a/frontend/src/i18n/locales/ru/common.ts
+++ b/frontend/src/i18n/locales/ru/common.ts
@@ -197,4 +197,13 @@ export const ruCommon = {
     value: "Количество",
     increase: "Увеличить количество",
   },
+  productPurchase: {
+    price: "Цена товара",
+    previousPrice: "Предыдущая цена {{price}}",
+    detailsUnavailable: "Описание товара скоро появится.",
+    adding: "Добавляем…",
+    addToCart: "Добавить в корзину",
+    added: "{{quantity}} × {{name}} добавлено в корзину.",
+    addError: "Не удалось добавить товар. Попробуйте ещё раз.",
+  },
 } satisfies CommonTranslations;

--- a/frontend/src/i18n/locales/ru/common.ts
+++ b/frontend/src/i18n/locales/ru/common.ts
@@ -209,4 +209,10 @@ export const ruCommon = {
   relatedProducts: {
     heading: "Вам также может понравиться",
   },
+  productPage: {
+    loading: "Загрузка товара",
+    loadingProduct: "Загружаем товар…",
+    loadError: "Не удалось загрузить товар. Попробуйте ещё раз.",
+    retry: "Попробовать снова",
+  },
 } satisfies CommonTranslations;

--- a/frontend/src/i18n/locales/ru/common.ts
+++ b/frontend/src/i18n/locales/ru/common.ts
@@ -183,4 +183,12 @@ export const ruCommon = {
     noSearchResults: "По запросу «{{term}}» товары не найдены.",
     noCategoryProducts: "В этой категории товары не найдены.",
   },
+  productGallery: {
+    region: "Изображения {{name}}",
+    image: "{{name}}, изображение {{current}} из {{total}}",
+    viewImage: "Показать изображение {{index}} товара {{name}}",
+    expand: "Увеличить {{name}}, изображение {{current}} из {{total}}",
+    dialog: "Увеличенное изображение {{name}}",
+    close: "Закрыть увеличенное изображение",
+  },
 } satisfies CommonTranslations;

--- a/frontend/src/i18n/locales/ru/common.ts
+++ b/frontend/src/i18n/locales/ru/common.ts
@@ -191,4 +191,10 @@ export const ruCommon = {
     dialog: "Увеличенное изображение {{name}}",
     close: "Закрыть увеличенное изображение",
   },
+  quantity: {
+    region: "Количество товара",
+    decrease: "Уменьшить количество",
+    value: "Количество",
+    increase: "Увеличить количество",
+  },
 } satisfies CommonTranslations;

--- a/frontend/src/pages/Product/Product.spec.tsx
+++ b/frontend/src/pages/Product/Product.spec.tsx
@@ -1,7 +1,8 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { Link, MemoryRouter, Route, Routes } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import i18n from "../../i18n/i18n";
 import { fetchCategoryTrail } from "../../services/categoryService/categoryService";
 import { fetchProductById, fetchProductPage } from "../../services/productService/productService";
 import type { Product } from "../../services/productService/types";
@@ -59,7 +60,8 @@ function renderProduct() {
 }
 
 describe("ProductPage", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    await i18n.changeLanguage("en");
     vi.mocked(fetchProductById).mockReset();
     vi.mocked(fetchCategoryTrail).mockReset();
     vi.mocked(fetchProductPage).mockReset();
@@ -116,10 +118,25 @@ describe("ProductPage", () => {
     vi.mocked(fetchProductById).mockRejectedValueOnce(new Error("Network unavailable")).mockResolvedValueOnce(product);
     renderProduct();
 
-    expect(await screen.findByRole("alert")).toHaveTextContent("Network unavailable");
+    expect(await screen.findByRole("alert")).toHaveTextContent("We couldn't load this product");
     fireEvent.click(screen.getByRole("button", { name: "Try again" }));
 
     expect(await screen.findByRole("heading", { name: "Match Football" })).toBeVisible();
     expect(fetchProductById).toHaveBeenCalledTimes(2);
+  });
+
+  it("updates an existing load error when the language changes", async () => {
+    vi.mocked(fetchProductById).mockRejectedValue(new Error("Unavailable"));
+    renderProduct();
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("We couldn't load this product");
+
+    await act(async () => {
+      await i18n.changeLanguage("ru");
+    });
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Не удалось загрузить товар");
+    expect(screen.getByRole("button", { name: "Попробовать снова" })).toBeVisible();
+    expect(fetchProductById).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/pages/Product/Product.tsx
+++ b/frontend/src/pages/Product/Product.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { useParams } from "react-router-dom";
 
 import Breadcrumbs, { type Crumb } from "../../components/Breadcrumbs/Breadcrumbs";
@@ -23,13 +24,14 @@ function categoryCrumbs(categories: Category[]): Crumb[] {
 }
 
 export default function ProductPage() {
+  const { t } = useTranslation("common");
   const { id } = useParams<{ id: string }>();
   const [product, setProduct] = useState<Product | null>(null);
   const [categoryTrail, setCategoryTrail] = useState<Category[]>([]);
   const [recommendations, setRecommendations] = useState<Product[]>([]);
   const [resolvedRequestKey, setResolvedRequestKey] = useState<string | null>(null);
   const [notFound, setNotFound] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [hasError, setHasError] = useState(false);
   const [reloadKey, setReloadKey] = useState(0);
   const requestKey = `${id ?? "missing"}#${reloadKey}`;
   const isLoading = resolvedRequestKey !== requestKey;
@@ -43,7 +45,7 @@ export default function ProductPage() {
       setCategoryTrail([]);
       setRecommendations([]);
       setNotFound(false);
-      setError(null);
+      setHasError(false);
 
       if (!id) {
         setNotFound(true);
@@ -54,9 +56,9 @@ export default function ProductPage() {
       let nextProduct: Product | null;
       try {
         nextProduct = await fetchProductById(id);
-      } catch (loadError) {
+      } catch {
         if (!cancelled) {
-          setError(loadError instanceof Error ? loadError.message : "Unable to load this product.");
+          setHasError(true);
           setResolvedRequestKey(requestKey);
         }
         return;
@@ -104,15 +106,15 @@ export default function ProductPage() {
   return (
     <PageContainer className="product-page">
       {isLoading ? (
-        <div aria-label="Product loading" aria-live="polite" className="product-page__status" role="status">
+        <div aria-label={t("productPage.loading")} aria-live="polite" className="product-page__status" role="status">
           <span className="product-page__spinner" />
-          Loading product…
+          {t("productPage.loadingProduct")}
         </div>
-      ) : error ? (
+      ) : hasError ? (
         <div className="product-page__status" role="alert">
-          <p>We couldn't load this product. {error}</p>
+          <p>{t("productPage.loadError")}</p>
           <button className="product-page__retry" onClick={() => setReloadKey((key) => key + 1)} type="button">
-            Try again
+            {t("productPage.retry")}
           </button>
         </div>
       ) : visibleProduct ? (


### PR DESCRIPTION
## Summary

- localize ProductGallery controls, image labels, and enlarged-image dialog
- localize QuantitySelector accessibility labels and actions
- localize ProductPurchasePanel prices, fallback copy, cart actions, and feedback
- reuse the locale-aware EUR formatter introduced by the catalog localization
- keep purchase feedback language-reactive by storing semantic state instead of translated strings
- localize RelatedProducts and Product page loading/error/retry states
- add unit and Playwright coverage for German and Russian product flows

## Why

The catalog now supports English, German, and Russian, but navigating to a product returned users to hardcoded English controls and English-formatted prices. This PR completes the next storefront i18n slice so the product browsing and purchase experience stays in the selected language.

## Scope note

Product names, descriptions, and category names remain API-owned catalog content. Their translation requires a separate backend model and content migration.
