### PR TITLE
feat(frontend): localize basket experience

### DIFF
--- a/e2e/store.spec.ts
+++ b/e2e/store.spec.ts
@@ -127,6 +127,34 @@ test("localizes product purchase and gallery controls", async ({ page }) => {
   await expect(galleryDialog).toHaveCount(0);
 });
 
+test("localizes basket items, promo code and order summary", async ({ page }) => {
+  await page.goto("/catalog");
+
+  await page.getByRole("button", { name: "Current language: English" }).click();
+  await page.getByRole("menuitemradio", { name: "DE Deutsch" }).click();
+  await page.getByRole("button", { name: "In den Warenkorb" }).first().click();
+  await page.getByRole("link", { name: "Warenkorb, 1 Artikel" }).click();
+
+  await expect(page.getByRole("heading", { level: 1, name: "Dein Warenkorb" })).toBeVisible();
+  await expect(page.getByRole("navigation", { name: "Breadcrumb-Navigation" })).toContainText("StartseiteWarenkorb");
+  await expect(page.getByRole("region", { name: "Artikel im Warenkorb" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Bestellübersicht" })).toBeVisible();
+  await expect(page.getByText("Gesamtsumme").locator("..")).toContainText(/\d+,\d{2}\s€/);
+
+  await page.getByPlaceholder("Aktionscode hinzufügen").fill("welcome10");
+  await page.getByRole("button", { name: "Anwenden" }).click();
+  await expect(page.getByLabel("Angewendeter Aktionscode")).toContainText("WELCOME10");
+  await expect(page.getByText("Rabatt", { exact: true })).toBeVisible();
+
+  await page.getByRole("button", { name: "Aktuelle Sprache: Deutsch" }).click();
+  await page.getByRole("menuitemradio", { name: "RU Русский" }).click();
+
+  await expect(page.getByRole("heading", { level: 1, name: "Ваша корзина" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Сумма заказа" })).toBeVisible();
+  await expect(page.getByLabel("Применённый промокод")).toContainText("Промокод применён");
+  await expect(page.getByRole("button", { name: "Удалить промокод WELCOME10" })).toBeVisible();
+});
+
 test("registers, shops with a promo code, opens profile and logs out", async ({ page }) => {
   const email = `playwright-${Date.now()}@example.com`;
 

--- a/frontend/src/components/Basket/BasketProductCard/BasketProductCard.spec.tsx
+++ b/frontend/src/components/Basket/BasketProductCard/BasketProductCard.spec.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import i18n from "../../../i18n/i18n";
 import type { CartItem } from "../../../services/cartService/types";
 import { useCart } from "../../context/useCart";
 import { BasketProductCard } from "./BasketProductCard";
@@ -23,7 +24,8 @@ describe("BasketProductCard", () => {
   const updateCartQuantity = vi.fn();
   const removeCartItem = vi.fn();
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    await i18n.changeLanguage("en");
     updateCartQuantity.mockReset();
     removeCartItem.mockReset();
     updateCartQuantity.mockResolvedValue(undefined);
@@ -55,5 +57,19 @@ describe("BasketProductCard", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Remove Match Football from cart" }));
     await waitFor(() => expect(removeCartItem).toHaveBeenCalledWith("item-id"));
+  });
+
+  it("localizes actions and prices for the selected language", async () => {
+    await i18n.changeLanguage("de");
+    render(
+      <MemoryRouter>
+        <BasketProductCard item={item} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole("article", { name: "Match Football im Warenkorb" })).toBeVisible();
+    expect(screen.getByText("69,98 €")).toBeVisible();
+    expect(screen.getByText("je 34,99 €")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Match Football aus dem Warenkorb entfernen" })).toBeVisible();
   });
 });

--- a/frontend/src/components/Basket/BasketProductCard/BasketProductCard.tsx
+++ b/frontend/src/components/Basket/BasketProductCard/BasketProductCard.tsx
@@ -1,8 +1,10 @@
 import { useState } from "react";
 import { PiTrash } from "react-icons/pi";
+import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 
 import type { CartItem } from "../../../services/cartService/types";
+import { formatMoney } from "../../../utils/formatMoney";
 import { IconButton } from "../../common/IconButton/IconButton";
 import { useCart } from "../../context/useCart";
 import { QuantitySelector } from "../../Product/QuantitySelector/QuantitySelector";
@@ -13,23 +15,20 @@ type BasketProductCardProps = {
   item: CartItem;
 };
 
-const moneyFormatter = new Intl.NumberFormat("en-IE", {
-  style: "currency",
-  currency: "EUR",
-});
-
 export function BasketProductCard({ item }: BasketProductCardProps) {
+  const { t, i18n } = useTranslation("common");
   const { removeCartItem, updateCartQuantity } = useCart();
   const [isUpdating, setIsUpdating] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [hasError, setHasError] = useState(false);
+  const language = i18n.resolvedLanguage ?? i18n.language;
 
   const update = async (request: () => Promise<void>) => {
     setIsUpdating(true);
-    setError(null);
+    setHasError(false);
     try {
       await request();
     } catch {
-      setError("We couldn't update this item. Please try again.");
+      setHasError(true);
     } finally {
       setIsUpdating(false);
     }
@@ -38,8 +37,12 @@ export function BasketProductCard({ item }: BasketProductCardProps) {
   const image = item.image ?? "/images/loading.gif";
 
   return (
-    <article aria-label={`${item.name} in cart`} className="basket-item">
-      <Link aria-label={`View ${item.name}`} className="basket-item__image-link" to={`/product/${item.productId}`}>
+    <article aria-label={t("basketItem.region", { name: item.name })} className="basket-item">
+      <Link
+        aria-label={t("basketItem.view", { name: item.name })}
+        className="basket-item__image-link"
+        to={`/product/${item.productId}`}
+      >
         <img
           alt={item.name}
           onError={(event) => {
@@ -58,18 +61,20 @@ export function BasketProductCard({ item }: BasketProductCardProps) {
             className="basket-item__remove"
             disabled={isUpdating}
             icon={<PiTrash />}
-            label={`Remove ${item.name} from cart`}
+            label={t("basketItem.remove", { name: item.name })}
             onClick={() => void update(() => removeCartItem(item.id))}
             size="small"
           />
         </div>
 
         {item.quantity > 1 && (
-          <p className="basket-item__unit-price">{moneyFormatter.format(item.unitPrice.amount / 100)} each</p>
+          <p className="basket-item__unit-price">
+            {t("basketItem.each", { price: formatMoney(item.unitPrice.amount, language) })}
+          </p>
         )}
 
         <div className="basket-item__footer">
-          <strong className="basket-item__line-total">{moneyFormatter.format(item.lineTotal.amount / 100)}</strong>
+          <strong className="basket-item__line-total">{formatMoney(item.lineTotal.amount, language)}</strong>
           <QuantitySelector
             className="basket-item__quantity"
             disabled={isUpdating}
@@ -79,9 +84,9 @@ export function BasketProductCard({ item }: BasketProductCardProps) {
           />
         </div>
 
-        {error && (
+        {hasError && (
           <p className="basket-item__error" role="alert">
-            {error}
+            {t("basketItem.updateError")}
           </p>
         )}
       </div>

--- a/frontend/src/components/Basket/BasketProductList/BasketProductList.spec.tsx
+++ b/frontend/src/components/Basket/BasketProductList/BasketProductList.spec.tsx
@@ -1,7 +1,8 @@
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import i18n from "../../../i18n/i18n";
 import type { CartResponse } from "../../../services/cartService/types";
 import { useCart } from "../../context/useCart";
 import { BasketProductList } from "./BasketProductList";
@@ -33,6 +34,10 @@ const cart: CartResponse = {
 };
 
 describe("BasketProductList", () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage("en");
+  });
+
   it("renders cart items as a semantic list", () => {
     vi.mocked(useCart).mockReturnValue({ cart } as never);
     render(
@@ -55,5 +60,18 @@ describe("BasketProductList", () => {
 
     expect(screen.getByRole("heading", { name: "Your cart is empty" })).toBeVisible();
     expect(screen.getByRole("link", { name: "Browse products" })).toHaveAttribute("href", "/catalog");
+  });
+
+  it("localizes the empty-cart guidance", async () => {
+    await i18n.changeLanguage("ru");
+    vi.mocked(useCart).mockReturnValue({ cart: { ...cart, items: [], totalQuantity: 0 } } as never);
+    render(
+      <MemoryRouter>
+        <BasketProductList />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole("heading", { name: "Ваша корзина пуста" })).toBeVisible();
+    expect(screen.getByRole("link", { name: "Перейти к товарам" })).toHaveAttribute("href", "/catalog");
   });
 });

--- a/frontend/src/components/Basket/BasketProductList/BasketProductList.tsx
+++ b/frontend/src/components/Basket/BasketProductList/BasketProductList.tsx
@@ -1,4 +1,5 @@
 import { PiShoppingCart } from "react-icons/pi";
+import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 
 import { useCart } from "../../context/useCart";
@@ -7,6 +8,7 @@ import { BasketProductCard } from "../BasketProductCard/BasketProductCard";
 import "./BasketProductList.scss";
 
 export function BasketProductList() {
+  const { t } = useTranslation("common");
   const { cart } = useCart();
   const items = cart?.items ?? [];
 
@@ -14,17 +16,17 @@ export function BasketProductList() {
     return (
       <section aria-labelledby="empty-cart-title" className="basket-empty">
         <PiShoppingCart aria-hidden="true" />
-        <h2 id="empty-cart-title">Your cart is empty</h2>
-        <p>Explore the catalog and add something for your next training session.</p>
+        <h2 id="empty-cart-title">{t("basketList.emptyTitle")}</h2>
+        <p>{t("basketList.emptyDescription")}</p>
         <Link className="basket-empty__link" to="/catalog">
-          Browse products
+          {t("basketList.browseProducts")}
         </Link>
       </section>
     );
   }
 
   return (
-    <section aria-label="Cart items" className="basket-list">
+    <section aria-label={t("basketList.items")} className="basket-list">
       <ul>
         {items.map((item) => (
           <li key={item.id}>

--- a/frontend/src/components/Basket/OrderSummary/OrderPromoCode/OrderPromoCode.spec.tsx
+++ b/frontend/src/components/Basket/OrderSummary/OrderPromoCode/OrderPromoCode.spec.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import i18n from "../../../../i18n/i18n";
 import type { CartResponse } from "../../../../services/cartService/types";
 import { useCart } from "../../../context/useCart";
 import OrderPromoCode from "./OrderPromoCode";
@@ -21,7 +22,8 @@ describe("OrderPromoCode", () => {
   const applyPromoCode = vi.fn();
   const removePromoCode = vi.fn();
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    await i18n.changeLanguage("en");
     applyPromoCode.mockReset();
     removePromoCode.mockReset();
     applyPromoCode.mockResolvedValue(undefined);
@@ -60,5 +62,17 @@ describe("OrderPromoCode", () => {
     fireEvent.click(screen.getByRole("button", { name: "Remove promo code WELCOME10" }));
 
     await waitFor(() => expect(removePromoCode).toHaveBeenCalledOnce());
+  });
+
+  it("localizes promo-code controls", async () => {
+    await i18n.changeLanguage("de");
+    render(<OrderPromoCode />);
+
+    expect(screen.getByRole("textbox", { name: "Aktionscode" })).toHaveAttribute(
+      "placeholder",
+      "Aktionscode hinzufügen"
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Anwenden" }));
+    expect(await screen.findByRole("alert")).toHaveTextContent("Gib einen Aktionscode ein.");
   });
 });

--- a/frontend/src/components/Basket/OrderSummary/OrderPromoCode/OrderPromoCode.tsx
+++ b/frontend/src/components/Basket/OrderSummary/OrderPromoCode/OrderPromoCode.tsx
@@ -1,7 +1,7 @@
-import { isAxiosError } from "axios";
 import { useState, type FormEvent } from "react";
 import { MdOutlineDiscount } from "react-icons/md";
 import { PiX } from "react-icons/pi";
+import { useTranslation } from "react-i18next";
 
 import Button from "../../../common/button/button";
 import { IconButton } from "../../../common/IconButton/IconButton";
@@ -10,22 +10,20 @@ import { useCart } from "../../../context/useCart";
 
 import "./OrderPromoCodeStyles.scss";
 
-function apiErrorMessage(error: unknown) {
-  if (isAxiosError<{ message?: string }>(error) && error.response?.data.message) return error.response.data.message;
-  return "We couldn't apply this promo code. Please try again.";
-}
+type PromoError = "required" | "request";
 
 export default function OrderPromoCode() {
+  const { t } = useTranslation("common");
   const { applyPromoCode, cart, removePromoCode } = useCart();
   const [promoCode, setPromoCode] = useState("");
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<PromoError | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     const normalizedCode = promoCode.trim().toUpperCase();
     if (!normalizedCode) {
-      setError("Enter a promo code.");
+      setError("required");
       return;
     }
 
@@ -34,8 +32,8 @@ export default function OrderPromoCode() {
     try {
       await applyPromoCode(normalizedCode);
       setPromoCode("");
-    } catch (submitError) {
-      setError(apiErrorMessage(submitError));
+    } catch {
+      setError("request");
     } finally {
       setIsSubmitting(false);
     }
@@ -46,8 +44,8 @@ export default function OrderPromoCode() {
     setError(null);
     try {
       await removePromoCode();
-    } catch (removeError) {
-      setError(apiErrorMessage(removeError));
+    } catch {
+      setError("request");
     } finally {
       setIsSubmitting(false);
     }
@@ -56,46 +54,50 @@ export default function OrderPromoCode() {
   return (
     <div className="order-promo">
       {cart?.discountCode && (
-        <div aria-label="Applied promo code" className="order-promo__applied">
+        <div aria-label={t("promoCode.applied")} className="order-promo__applied">
           <MdOutlineDiscount aria-hidden="true" />
           <div>
             <strong>{cart.discountCode.code}</strong>
-            <span>{cart.discountCode.description}</span>
+            <span>{t("promoCode.appliedDescription")}</span>
           </div>
           <IconButton
             disabled={isSubmitting}
             icon={<PiX />}
-            label={`Remove promo code ${cart.discountCode.code}`}
+            label={t("promoCode.remove", { code: cart.discountCode.code })}
             onClick={() => void removeCode()}
             size="small"
           />
         </div>
       )}
 
-      <form aria-label="Promo code" className="order-promo__form" onSubmit={(event) => void handleSubmit(event)}>
+      <form
+        aria-label={t("promoCode.form")}
+        className="order-promo__form"
+        onSubmit={(event) => void handleSubmit(event)}
+      >
         <InputField
           aria-describedby={error ? "promo-code-error" : undefined}
-          aria-label="Promo code"
+          aria-label={t("promoCode.label")}
           disabled={isSubmitting}
           icon={<MdOutlineDiscount />}
           inputClassName="order-promo__input"
           isValid={!error}
           name="promoCode"
           onChange={setPromoCode}
-          placeholder="Add promo code"
+          placeholder={t("promoCode.placeholder")}
           value={promoCode}
         />
         <Button
           className="order-promo__apply"
           disabled={isSubmitting}
-          text={isSubmitting ? "Applying…" : "Apply"}
+          text={isSubmitting ? t("promoCode.applying") : t("promoCode.apply")}
           type="submit"
         />
       </form>
 
       {error && (
         <p className="order-promo__error" id="promo-code-error" role="alert">
-          {error}
+          {t(`promoCode.${error}`)}
         </p>
       )}
     </div>

--- a/frontend/src/components/Basket/OrderSummary/OrderSummary.spec.tsx
+++ b/frontend/src/components/Basket/OrderSummary/OrderSummary.spec.tsx
@@ -1,7 +1,8 @@
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import i18n from "../../../i18n/i18n";
 import type { CartResponse } from "../../../services/cartService/types";
 import { useCart } from "../../context/useCart";
 import OrderSummary from "./OrderSummary";
@@ -20,6 +21,10 @@ const cart: CartResponse = {
 };
 
 describe("OrderSummary", () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage("en");
+  });
+
   it("renders only totals calculated by the backend", () => {
     vi.mocked(useCart).mockReturnValue({ cart } as never);
     render(
@@ -44,5 +49,21 @@ describe("OrderSummary", () => {
 
     expect(screen.getByRole("button", { name: "Checkout unavailable" })).toBeDisabled();
     expect(screen.getByRole("link", { name: "Continue shopping" })).toHaveAttribute("href", "/catalog");
+  });
+
+  it("localizes labels and server-calculated totals", async () => {
+    await i18n.changeLanguage("de");
+    vi.mocked(useCart).mockReturnValue({ cart } as never);
+    render(
+      <MemoryRouter>
+        <OrderSummary />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole("heading", { name: "Bestellübersicht" })).toBeVisible();
+    expect(screen.getByText("Zwischensumme").parentElement).toHaveTextContent("Zwischensumme100,00 €");
+    expect(screen.getByText("Rabatt").parentElement).toHaveTextContent("Rabatt-10,00 €");
+    expect(screen.getByText("Gesamtsumme").parentElement).toHaveTextContent("Gesamtsumme90,00 €");
+    expect(screen.getByRole("link", { name: "Weiter einkaufen" })).toHaveAttribute("href", "/catalog");
   });
 });

--- a/frontend/src/components/Basket/OrderSummary/OrderSummary.tsx
+++ b/frontend/src/components/Basket/OrderSummary/OrderSummary.tsx
@@ -1,42 +1,40 @@
 import { PiArrowRight } from "react-icons/pi";
+import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 
+import { formatMoney } from "../../../utils/formatMoney";
 import Button from "../../common/button/button";
 import { useCart } from "../../context/useCart";
 import OrderPromoCode from "./OrderPromoCode/OrderPromoCode";
 
 import "./OrderSummaryStyles.scss";
 
-const moneyFormatter = new Intl.NumberFormat("en-IE", {
-  style: "currency",
-  currency: "EUR",
-});
-
-const money = (amount = 0) => moneyFormatter.format(amount / 100);
-
 export default function OrderSummary() {
+  const { t, i18n } = useTranslation("common");
   const { cart } = useCart();
+  const language = i18n.resolvedLanguage ?? i18n.language;
+  const money = (amount = 0) => formatMoney(amount, language);
   const subtotal = cart?.subtotal.amount ?? 0;
   const discount = cart?.discount.amount ?? 0;
   const total = cart?.total.amount ?? 0;
 
   return (
     <aside aria-labelledby="order-summary-title" className="order-summary">
-      <h2 id="order-summary-title">Order Summary</h2>
+      <h2 id="order-summary-title">{t("orderSummary.title")}</h2>
 
       <dl className="order-summary__amounts">
         <div>
-          <dt>Subtotal</dt>
+          <dt>{t("orderSummary.subtotal")}</dt>
           <dd>{money(subtotal)}</dd>
         </div>
         {discount > 0 && (
           <div className="order-summary__discount">
-            <dt>Discount</dt>
-            <dd>-{money(discount)}</dd>
+            <dt>{t("orderSummary.discount")}</dt>
+            <dd>{money(-discount)}</dd>
           </div>
         )}
         <div className="order-summary__total">
-          <dt>Total</dt>
+          <dt>{t("orderSummary.total")}</dt>
           <dd>{money(total)}</dd>
         </div>
       </dl>
@@ -48,13 +46,13 @@ export default function OrderSummary() {
         className="order-summary__checkout"
         disabled
         icon={<PiArrowRight />}
-        text="Checkout unavailable"
+        text={t("orderSummary.checkoutUnavailable")}
       />
       <p className="order-summary__checkout-note" id="checkout-note">
-        Checkout is not available in this demo yet.
+        {t("orderSummary.checkoutNote")}
       </p>
       <Link className="order-summary__continue" to="/catalog">
-        Continue shopping
+        {t("orderSummary.continueShopping")}
       </Link>
     </aside>
   );

--- a/frontend/src/i18n/locales/de/common.ts
+++ b/frontend/src/i18n/locales/de/common.ts
@@ -232,4 +232,16 @@ export const deCommon = {
     emptyDescription: "Entdecke den Katalog und finde etwas für deine nächste Trainingseinheit.",
     browseProducts: "Produkte entdecken",
   },
+  promoCode: {
+    applied: "Angewendeter Aktionscode",
+    appliedDescription: "Aktionscode angewendet",
+    remove: "Aktionscode {{code}} entfernen",
+    form: "Aktionscode",
+    label: "Aktionscode",
+    placeholder: "Aktionscode hinzufügen",
+    applying: "Wird angewendet…",
+    apply: "Anwenden",
+    required: "Gib einen Aktionscode ein.",
+    request: "Der Aktionscode konnte nicht aktualisiert werden. Bitte versuche es erneut.",
+  },
 } satisfies CommonTranslations;

--- a/frontend/src/i18n/locales/de/common.ts
+++ b/frontend/src/i18n/locales/de/common.ts
@@ -244,4 +244,13 @@ export const deCommon = {
     required: "Gib einen Aktionscode ein.",
     request: "Der Aktionscode konnte nicht aktualisiert werden. Bitte versuche es erneut.",
   },
+  orderSummary: {
+    title: "Bestellübersicht",
+    subtotal: "Zwischensumme",
+    discount: "Rabatt",
+    total: "Gesamtsumme",
+    checkoutUnavailable: "Kasse nicht verfügbar",
+    checkoutNote: "Die Kasse ist in dieser Demo noch nicht verfügbar.",
+    continueShopping: "Weiter einkaufen",
+  },
 } satisfies CommonTranslations;

--- a/frontend/src/i18n/locales/de/common.ts
+++ b/frontend/src/i18n/locales/de/common.ts
@@ -219,4 +219,11 @@ export const deCommon = {
     loadError: "Dieses Produkt konnte nicht geladen werden. Bitte versuche es erneut.",
     retry: "Erneut versuchen",
   },
+  basketItem: {
+    region: "{{name}} im Warenkorb",
+    view: "{{name}} ansehen",
+    remove: "{{name}} aus dem Warenkorb entfernen",
+    each: "je {{price}}",
+    updateError: "Dieser Artikel konnte nicht aktualisiert werden. Bitte versuche es erneut.",
+  },
 } satisfies CommonTranslations;

--- a/frontend/src/i18n/locales/de/common.ts
+++ b/frontend/src/i18n/locales/de/common.ts
@@ -226,4 +226,10 @@ export const deCommon = {
     each: "je {{price}}",
     updateError: "Dieser Artikel konnte nicht aktualisiert werden. Bitte versuche es erneut.",
   },
+  basketList: {
+    items: "Artikel im Warenkorb",
+    emptyTitle: "Dein Warenkorb ist leer",
+    emptyDescription: "Entdecke den Katalog und finde etwas für deine nächste Trainingseinheit.",
+    browseProducts: "Produkte entdecken",
+  },
 } satisfies CommonTranslations;

--- a/frontend/src/i18n/locales/de/common.ts
+++ b/frontend/src/i18n/locales/de/common.ts
@@ -253,4 +253,11 @@ export const deCommon = {
     checkoutNote: "Die Kasse ist in dieser Demo noch nicht verfügbar.",
     continueShopping: "Weiter einkaufen",
   },
+  basketPage: {
+    breadcrumb: "Warenkorb",
+    title: "Dein Warenkorb",
+    loading: "Dein Warenkorb wird geladen…",
+    loadError: "Dein Warenkorb konnte nicht geladen werden. Bitte versuche es erneut.",
+    retry: "Erneut versuchen",
+  },
 } satisfies CommonTranslations;

--- a/frontend/src/i18n/locales/en/common.ts
+++ b/frontend/src/i18n/locales/en/common.ts
@@ -222,6 +222,12 @@ export const enCommon = {
     each: "{{price}} each",
     updateError: "We couldn't update this item. Please try again.",
   },
+  basketList: {
+    items: "Cart items",
+    emptyTitle: "Your cart is empty",
+    emptyDescription: "Explore the catalog and add something for your next training session.",
+    browseProducts: "Browse products",
+  },
 } as const;
 
 export type CommonTranslations = {

--- a/frontend/src/i18n/locales/en/common.ts
+++ b/frontend/src/i18n/locales/en/common.ts
@@ -215,6 +215,13 @@ export const enCommon = {
     loadError: "We couldn't load this product. Please try again.",
     retry: "Try again",
   },
+  basketItem: {
+    region: "{{name}} in cart",
+    view: "View {{name}}",
+    remove: "Remove {{name}} from cart",
+    each: "{{price}} each",
+    updateError: "We couldn't update this item. Please try again.",
+  },
 } as const;
 
 export type CommonTranslations = {

--- a/frontend/src/i18n/locales/en/common.ts
+++ b/frontend/src/i18n/locales/en/common.ts
@@ -249,6 +249,13 @@ export const enCommon = {
     checkoutNote: "Checkout is not available in this demo yet.",
     continueShopping: "Continue shopping",
   },
+  basketPage: {
+    breadcrumb: "Cart",
+    title: "Your cart",
+    loading: "Loading your cart…",
+    loadError: "We couldn't load your cart. Please try again.",
+    retry: "Try again",
+  },
 } as const;
 
 export type CommonTranslations = {

--- a/frontend/src/i18n/locales/en/common.ts
+++ b/frontend/src/i18n/locales/en/common.ts
@@ -228,6 +228,18 @@ export const enCommon = {
     emptyDescription: "Explore the catalog and add something for your next training session.",
     browseProducts: "Browse products",
   },
+  promoCode: {
+    applied: "Applied promo code",
+    appliedDescription: "Promo code applied",
+    remove: "Remove promo code {{code}}",
+    form: "Promo code",
+    label: "Promo code",
+    placeholder: "Add promo code",
+    applying: "Applying…",
+    apply: "Apply",
+    required: "Enter a promo code.",
+    request: "We couldn't update this promo code. Please try again.",
+  },
 } as const;
 
 export type CommonTranslations = {

--- a/frontend/src/i18n/locales/en/common.ts
+++ b/frontend/src/i18n/locales/en/common.ts
@@ -240,6 +240,15 @@ export const enCommon = {
     required: "Enter a promo code.",
     request: "We couldn't update this promo code. Please try again.",
   },
+  orderSummary: {
+    title: "Order Summary",
+    subtotal: "Subtotal",
+    discount: "Discount",
+    total: "Total",
+    checkoutUnavailable: "Checkout unavailable",
+    checkoutNote: "Checkout is not available in this demo yet.",
+    continueShopping: "Continue shopping",
+  },
 } as const;
 
 export type CommonTranslations = {

--- a/frontend/src/i18n/locales/ru/common.ts
+++ b/frontend/src/i18n/locales/ru/common.ts
@@ -240,4 +240,13 @@ export const ruCommon = {
     required: "Введите промокод.",
     request: "Не удалось обновить промокод. Попробуйте ещё раз.",
   },
+  orderSummary: {
+    title: "Сумма заказа",
+    subtotal: "Стоимость товаров",
+    discount: "Скидка",
+    total: "Итого",
+    checkoutUnavailable: "Оформление недоступно",
+    checkoutNote: "Оформление заказа пока недоступно в демоверсии.",
+    continueShopping: "Продолжить покупки",
+  },
 } satisfies CommonTranslations;

--- a/frontend/src/i18n/locales/ru/common.ts
+++ b/frontend/src/i18n/locales/ru/common.ts
@@ -249,4 +249,11 @@ export const ruCommon = {
     checkoutNote: "Оформление заказа пока недоступно в демоверсии.",
     continueShopping: "Продолжить покупки",
   },
+  basketPage: {
+    breadcrumb: "Корзина",
+    title: "Ваша корзина",
+    loading: "Загружаем корзину…",
+    loadError: "Не удалось загрузить корзину. Попробуйте ещё раз.",
+    retry: "Попробовать снова",
+  },
 } satisfies CommonTranslations;

--- a/frontend/src/i18n/locales/ru/common.ts
+++ b/frontend/src/i18n/locales/ru/common.ts
@@ -228,4 +228,16 @@ export const ruCommon = {
     emptyDescription: "Откройте каталог и выберите товары для следующей тренировки.",
     browseProducts: "Перейти к товарам",
   },
+  promoCode: {
+    applied: "Применённый промокод",
+    appliedDescription: "Промокод применён",
+    remove: "Удалить промокод {{code}}",
+    form: "Промокод",
+    label: "Промокод",
+    placeholder: "Добавить промокод",
+    applying: "Применяем…",
+    apply: "Применить",
+    required: "Введите промокод.",
+    request: "Не удалось обновить промокод. Попробуйте ещё раз.",
+  },
 } satisfies CommonTranslations;

--- a/frontend/src/i18n/locales/ru/common.ts
+++ b/frontend/src/i18n/locales/ru/common.ts
@@ -215,4 +215,11 @@ export const ruCommon = {
     loadError: "Не удалось загрузить товар. Попробуйте ещё раз.",
     retry: "Попробовать снова",
   },
+  basketItem: {
+    region: "{{name}} в корзине",
+    view: "Открыть {{name}}",
+    remove: "Удалить {{name}} из корзины",
+    each: "{{price}} за шт.",
+    updateError: "Не удалось обновить товар. Попробуйте ещё раз.",
+  },
 } satisfies CommonTranslations;

--- a/frontend/src/i18n/locales/ru/common.ts
+++ b/frontend/src/i18n/locales/ru/common.ts
@@ -222,4 +222,10 @@ export const ruCommon = {
     each: "{{price}} за шт.",
     updateError: "Не удалось обновить товар. Попробуйте ещё раз.",
   },
+  basketList: {
+    items: "Товары в корзине",
+    emptyTitle: "Ваша корзина пуста",
+    emptyDescription: "Откройте каталог и выберите товары для следующей тренировки.",
+    browseProducts: "Перейти к товарам",
+  },
 } satisfies CommonTranslations;

--- a/frontend/src/pages/Basket/Basket.spec.tsx
+++ b/frontend/src/pages/Basket/Basket.spec.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import i18n from "../../i18n/i18n";
 import type { CartResponse } from "../../services/cartService/types";
 import { useCart } from "../../components/context/useCart";
 import BasketPage from "./Basket";
@@ -38,7 +39,8 @@ const cart: CartResponse = {
 describe("BasketPage", () => {
   const refreshCart = vi.fn();
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    await i18n.changeLanguage("en");
     refreshCart.mockReset();
   });
 
@@ -96,5 +98,26 @@ describe("BasketPage", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Try again" }));
     await waitFor(() => expect(refreshCart).toHaveBeenCalledOnce());
+    expect(screen.getByRole("alert")).not.toHaveTextContent("Network unavailable");
+  });
+
+  it("localizes the page and its error state", async () => {
+    await i18n.changeLanguage("ru");
+    vi.mocked(useCart).mockReturnValue({
+      cart: null,
+      cartError: "Network unavailable",
+      isCartLoading: false,
+      refreshCart,
+    } as never);
+    render(
+      <MemoryRouter>
+        <BasketPage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole("heading", { name: "Ваша корзина" })).toBeVisible();
+    expect(screen.getByRole("navigation", { name: "Навигационная цепочка" })).toHaveTextContent("ГлавнаяКорзина");
+    expect(screen.getByRole("alert")).toHaveTextContent("Не удалось загрузить корзину");
+    expect(screen.getByRole("button", { name: "Попробовать снова" })).toBeVisible();
   });
 });

--- a/frontend/src/pages/Basket/Basket.tsx
+++ b/frontend/src/pages/Basket/Basket.tsx
@@ -7,25 +7,26 @@ import { useCart } from "../../components/context/useCart";
 import "./BasketPageStyles.scss";
 
 export default function BasketPage() {
+  const { t } = useTranslation("common");
   const { cart, cartError, isCartLoading, refreshCart } = useCart();
   const hasItems = Boolean(cart?.items.length);
 
   return (
     <PageContainer className="basket-page">
-      <Breadcrumbs crumbs={[{ name: "Cart", path: "/basket" }]} includeCatalog={false} />
+      <Breadcrumbs crumbs={[{ name: t("basketPage.breadcrumb"), path: "/basket" }]} includeCatalog={false} />
       <main aria-labelledby="cart-title" className="basket-page__main">
-        <h1 id="cart-title">Your cart</h1>
+        <h1 id="cart-title">{t("basketPage.title")}</h1>
 
         {isCartLoading ? (
           <div aria-live="polite" className="basket-page__status" role="status">
             <span className="basket-page__spinner" />
-            Loading your cart…
+            {t("basketPage.loading")}
           </div>
         ) : cartError ? (
           <div className="basket-page__status" role="alert">
-            <p>We couldn't load your cart. {cartError}</p>
+            <p>{t("basketPage.loadError")}</p>
             <button className="basket-page__retry" onClick={() => void refreshCart()} type="button">
-              Try again
+              {t("basketPage.retry")}
             </button>
           </div>
         ) : (
@@ -38,3 +39,4 @@ export default function BasketPage() {
     </PageContainer>
   );
 }
+import { useTranslation } from "react-i18next";


### PR DESCRIPTION
## Summary

- localize basket item actions, empty/loading/error states, promo-code controls, and order summary for English, German, and Russian
- format item prices and server-calculated totals according to the active locale
- keep technical API errors out of the customer-facing interface and resolve displayed messages from semantic UI state
- add component coverage and a Playwright flow that switches languages with a populated cart and an applied promo code

## User impact

Customers can now use the complete basket flow in any supported interface language. Currency presentation, accessible labels, validation feedback, and navigation update immediately when the language changes.
