### PR TITLE
feat(deploy): prepare Vercel Services and Neon deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,55 @@ docker compose run --rm migrate node --import tsx backend/prisma/seed.ts
 
 Open `http://localhost:8080`. Nginx serves the SPA and proxies `/api` to NestJS under the same origin.
 
+## Vercel + Neon deployment
+
+The repository contains `vercel.json` and one `Dockerfile.vercel` per workspace. Vercel
+Services deploys both containers under one origin: `/api/*` is routed to NestJS and all
+other paths are routed to the React SPA. The Services framework is currently a Vercel
+beta feature, so enable it in the project's Build and Deployment settings before the
+first deployment.
+
+### 1. Create the database
+
+Create a PostgreSQL project in [Neon](https://neon.tech/), copy its pooled connection
+string and keep it private. The connection string is used as `DATABASE_URL`; do not put
+it in the repository or in a `VITE_*` variable.
+
+### 2. Configure the Vercel project
+
+Import this repository as one Vercel project with the repository root (`.`) as the Root
+Directory and select `Services` as the Framework Preset. Add these variables for the
+Production environment (and separate values for Preview if needed):
+
+```text
+NODE_ENV=production
+DATABASE_URL=postgresql://...        # Neon pooled URL
+JWT_ACCESS_SECRET=<at least 32 random characters>
+COOKIE_SECRET=<at least 32 random characters>
+FRONTEND_ORIGIN=https://<your-domain>
+ACCESS_TOKEN_TTL=15m
+REFRESH_TOKEN_DAYS=30
+```
+
+Do not set `PORT`: Vercel injects the port used by the container. `VITE_API_BASE_URL`
+remains `/api/v1`, so browser requests and authentication cookies stay same-origin.
+
+### 3. Apply migrations and seed demo data
+
+Vercel builds the image but does not change the database schema automatically. Run the
+release step from a machine with the Neon URL in its environment, then deploy the
+project:
+
+```bash
+DATABASE_URL="<neon-pooled-url>" npm run prisma:deploy --workspace backend
+DATABASE_URL="<neon-pooled-url>" npm run db:seed
+npx vercel deploy
+```
+
+Migrations are idempotent and should be run once per database before the first release.
+Keep the Neon URL and application secrets in Vercel Environment Variables or a local
+untracked `.env` file only.
+
 ## Commands
 
 - `npm run build` — build frontend and backend.

--- a/backend/Dockerfile.vercel
+++ b/backend/Dockerfile.vercel
@@ -1,0 +1,37 @@
+FROM node:24-bookworm-slim AS build
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends openssl \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Vercel builds this service with backend/ as its context.
+COPY package.json ./
+RUN npm install
+
+COPY . .
+
+# Prisma Client generation only needs the schema at image-build time.
+# The real DATABASE_URL is injected by Vercel at runtime.
+RUN DATABASE_URL=postgresql://build:build@localhost:5432/build npm run prisma:generate
+RUN npm run build
+
+FROM node:24-bookworm-slim AS runtime
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends openssl \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV NODE_ENV=production
+WORKDIR /app
+
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/dist ./dist
+COPY --from=build /app/prisma ./prisma
+COPY --from=build /app/prisma.config.ts ./prisma.config.ts
+COPY --from=build /app/package.json ./package.json
+
+USER node
+EXPOSE 3000
+CMD ["node", "dist/main.js"]

--- a/frontend/Dockerfile.vercel
+++ b/frontend/Dockerfile.vercel
@@ -5,7 +5,9 @@ COPY package.json ./
 RUN npm install
 
 COPY . .
-RUN npm run build
+RUN npx tsc --noEmit -p tsconfig.app.json \
+  && npx tsc --noEmit -p tsconfig.node.json \
+  && NODE_ENV=production npx vite build
 
 FROM nginx:1.29-alpine
 

--- a/frontend/Dockerfile.vercel
+++ b/frontend/Dockerfile.vercel
@@ -1,0 +1,15 @@
+FROM node:24-bookworm-slim AS build
+
+WORKDIR /app
+COPY package.json ./
+RUN npm install
+
+COPY . .
+RUN npm run build
+
+FROM nginx:1.29-alpine
+
+COPY nginx.vercel.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/dist /usr/share/nginx/html
+
+EXPOSE 80

--- a/frontend/nginx.vercel.conf
+++ b/frontend/nginx.vercel.conf
@@ -1,0 +1,10 @@
+server {
+  listen 80;
+  server_name _;
+  root /usr/share/nginx/html;
+  index index.html;
+
+  location / {
+    try_files $uri $uri/ /index.html;
+  }
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -10,10 +10,12 @@ const apiProxy = {
 };
 
 // https://vite.dev/config/
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
   // base: "/eCommerce-group-project/", // gh-page
   base: "/", // for Netify
-  plugins: [react(), eslint()],
+  // Production builds are linted by CI before deployment. Skipping the Vite
+  // lint transform keeps standalone service builds independent of root config.
+  plugins: [react(), ...(mode === "production" ? [] : [eslint()])],
   server: {
     proxy: apiProxy,
   },
@@ -32,4 +34,4 @@ export default defineConfig({
       provider: "v8",
     },
   },
-});
+}));

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "services": {
+    "frontend": {
+      "root": "frontend/",
+      "runtime": "container",
+      "entrypoint": "Dockerfile.vercel"
+    },
+    "backend": {
+      "root": "backend/",
+      "runtime": "container",
+      "entrypoint": "Dockerfile.vercel"
+    }
+  },
+  "rewrites": [
+    { "source": "/api", "destination": { "service": "backend" } },
+    { "source": "/api/(.*)", "destination": { "service": "backend" } },
+    { "source": "/(.*)", "destination": { "service": "frontend" } }
+  ]
+}


### PR DESCRIPTION
## Summary

Prepare a separate deployment path for the full-stack application on Vercel + Neon, without committing credentials.

## What's included

- Added standalone `Dockerfile.vercel` images for the NestJS API and React SPA.
- Added a Vercel Services routing configuration:
  - `/api/*` → backend container
  - all other paths → frontend container
- Added SPA fallback Nginx configuration for client-side routes.
- Made the production Vite build independent from root-workspace-only tooling.
- Documented Neon environment variables, Prisma release migrations, seed, and Vercel setup in `README.md`.

## Verification

- `npm run build`
- `npm run lint`
- `npm run format:check`
- Prisma schema validation
- Docker build: backend Vercel image
- Docker build: frontend Vercel image

## Deployment notes

Vercel Services must be enabled for the project and is currently a beta feature. Neon remains the persistent PostgreSQL source; migrations are intentionally a separate release step. No secrets or database URLs are included in this PR.