### PR TITLE
fix(frontend): polish navigation and infinite highlights carousel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ eslint.config.js
 *.sw?
 .flaskenv*
 /design-reference
+**/.vite/

--- a/e2e/store.spec.ts
+++ b/e2e/store.spec.ts
@@ -284,7 +284,7 @@ test("registers, shops with a promo code, opens profile and logs out", async ({ 
 
   const accountLink = page.getByRole("link", { name: "Open Playwright's account" });
   await expect(accountLink).toContainText("PU");
-  await expect(accountLink).toContainText("Hi, Playwright");
+  await expect(accountLink).toContainText("Playwright");
 
   await page.goto("/login");
   await expect(page).toHaveURL(/\/$/);

--- a/frontend/eslint.config.ts
+++ b/frontend/eslint.config.ts
@@ -8,7 +8,7 @@ import typescriptPlugin from "@typescript-eslint/eslint-plugin";
 import prettierPlugin from "eslint-plugin-prettier";
 
 export default tseslint.config(
-  { ignores: ["dist"] },
+  { ignores: ["dist", ".vite"] },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ["**/*.{ts,tsx}"],

--- a/frontend/src/components/Header/AnnouncementBar/AnnouncementBar.spec.tsx
+++ b/frontend/src/components/Header/AnnouncementBar/AnnouncementBar.spec.tsx
@@ -1,22 +1,37 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import i18n from "../../../i18n/i18n";
+import { AuthContext, type AuthContextValue } from "../../context/AuthContext";
 
 import { AnnouncementBar } from "./AnnouncementBar";
 
 describe("AnnouncementBar", () => {
+  const authValue: AuthContextValue = {
+    user: null,
+    isAuthenticated: false,
+    loading: false,
+    refreshUser: vi.fn(),
+    logout: vi.fn(),
+  };
+
+  function renderAnnouncement(auth: Partial<AuthContextValue> = {}) {
+    return render(
+      <AuthContext.Provider value={{ ...authValue, ...auth }}>
+        <MemoryRouter>
+          <AnnouncementBar />
+        </MemoryRouter>
+      </AuthContext.Provider>
+    );
+  }
+
   beforeEach(async () => {
     await i18n.changeLanguage("en");
   });
 
   it("renders the promotion and links to registration", () => {
-    render(
-      <MemoryRouter>
-        <AnnouncementBar />
-      </MemoryRouter>
-    );
+    renderAnnouncement();
 
     const announcement = screen.getByRole("complementary", {
       name: "Promotional announcement",
@@ -28,11 +43,7 @@ describe("AnnouncementBar", () => {
   });
 
   it("can be dismissed", () => {
-    render(
-      <MemoryRouter>
-        <AnnouncementBar />
-      </MemoryRouter>
-    );
+    renderAnnouncement();
 
     fireEvent.click(screen.getByRole("button", { name: "Dismiss promotion" }));
 
@@ -42,15 +53,23 @@ describe("AnnouncementBar", () => {
   it("updates the promotion when the language changes", async () => {
     await i18n.changeLanguage("de");
 
-    render(
-      <MemoryRouter>
-        <AnnouncementBar />
-      </MemoryRouter>
-    );
+    renderAnnouncement();
 
     expect(screen.getByRole("complementary", { name: "Aktionsankündigung" })).toHaveTextContent(
       "Registriere dich und erhalte 20 % Rabatt auf deine erste Bestellung."
     );
     expect(screen.getByRole("link", { name: "Jetzt registrieren" })).toHaveAttribute("href", "/sign-up");
+  });
+
+  it("stays hidden while authentication is loading", () => {
+    renderAnnouncement({ loading: true });
+
+    expect(screen.queryByRole("complementary", { name: "Promotional announcement" })).not.toBeInTheDocument();
+  });
+
+  it("stays hidden for authenticated users", () => {
+    renderAnnouncement({ isAuthenticated: true });
+
+    expect(screen.queryByRole("complementary", { name: "Promotional announcement" })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/Header/AnnouncementBar/AnnouncementBar.tsx
+++ b/frontend/src/components/Header/AnnouncementBar/AnnouncementBar.tsx
@@ -5,14 +5,16 @@ import { Link } from "react-router-dom";
 
 import { IconButton } from "../../common/IconButton/IconButton";
 import { PageContainer } from "../../common/PageContainer/PageContainer";
+import { useAuth } from "../../context/useAuth";
 
 import "./AnnouncementBar.scss";
 
 export function AnnouncementBar() {
   const { t } = useTranslation("common");
+  const { isAuthenticated, loading } = useAuth();
   const [isVisible, setIsVisible] = useState(true);
 
-  if (!isVisible) {
+  if (loading || isAuthenticated || !isVisible) {
     return null;
   }
 

--- a/frontend/src/components/Header/HeaderActions/HeaderActions.spec.tsx
+++ b/frontend/src/components/Header/HeaderActions/HeaderActions.spec.tsx
@@ -69,7 +69,7 @@ describe("HeaderActions", () => {
 
     expect(screen.getByRole("link", { name: "Shopping cart, 3 items" })).toHaveTextContent("3");
     expect(screen.getByRole("link", { name: "Open Yevhen's account" })).toHaveAttribute("href", "/profile");
-    expect(screen.getByRole("link", { name: "Open Yevhen's account" })).toHaveTextContent("YRHi, YevhenMy account");
+    expect(screen.getByRole("link", { name: "Open Yevhen's account" })).toHaveTextContent("YRYevhenMy account");
   });
 
   it("does not expose the wrong account destination while authentication is loading", () => {

--- a/frontend/src/components/Header/HeaderActions/HeaderActions.tsx
+++ b/frontend/src/components/Header/HeaderActions/HeaderActions.tsx
@@ -67,13 +67,7 @@ export function HeaderActions({ className = "", ...props }: HeaderActionsProps) 
             </span>
           )}
           <span className="header-actions__account-copy">
-            <strong>
-              {isAuthenticated
-                ? firstName
-                  ? t("headerActions.greeting", { name: firstName })
-                  : t("headerActions.myAccount")
-                : t("headerActions.signIn")}
-            </strong>
+            <strong>{isAuthenticated ? firstName || t("headerActions.myAccount") : t("headerActions.signIn")}</strong>
             <span>{isAuthenticated ? t("headerActions.myAccount") : t("headerActions.yourAccount")}</span>
           </span>
         </Link>

--- a/frontend/src/components/Home/StoreHighlights/StoreHighlights.spec.tsx
+++ b/frontend/src/components/Home/StoreHighlights/StoreHighlights.spec.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import i18n from "../../../i18n/i18n";
@@ -9,6 +9,7 @@ const scrollBy = vi.fn();
 
 describe("StoreHighlights", () => {
   beforeEach(async () => {
+    vi.useRealTimers();
     await i18n.changeLanguage("en");
     scrollBy.mockReset();
     Object.defineProperty(HTMLElement.prototype, "scrollBy", {
@@ -21,15 +22,20 @@ describe("StoreHighlights", () => {
     render(<StoreHighlights />);
 
     expect(screen.getByRole("region", { name: "WHY SPORT GEAR" })).toBeInTheDocument();
-    expect(screen.getByRole("list", { name: "Store advantages" })).toBeInTheDocument();
+    const list = screen.getByRole("list", { name: "Store advantages" });
+    const cards = list.querySelectorAll("article");
+    Object.defineProperty(cards[0], "offsetLeft", { configurable: true, value: 8 });
+    Object.defineProperty(cards[1], "offsetLeft", { configurable: true, value: 428 });
+    Object.defineProperty(cards[4], "offsetLeft", { configurable: true, value: 1688 });
+
     expect(screen.getAllByRole("listitem")).toHaveLength(4);
-    expect(screen.getByText("Server-priced catalog")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Server-priced catalog" })).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Next advantages" }));
-    expect(scrollBy).toHaveBeenCalledWith({ behavior: "smooth", left: 360 });
+    expect(scrollBy).toHaveBeenCalledWith({ behavior: "smooth", left: 420 });
 
     fireEvent.click(screen.getByRole("button", { name: "Previous advantages" }));
-    expect(scrollBy).toHaveBeenCalledWith({ behavior: "smooth", left: -360 });
+    expect(scrollBy).toHaveBeenCalledWith({ behavior: "smooth", left: -420 });
   });
 
   it("localizes cards, list, and carousel controls", async () => {
@@ -39,9 +45,42 @@ describe("StoreHighlights", () => {
 
     expect(screen.getByRole("region", { name: "ПОЧЕМУ SPORT GEAR" })).toBeInTheDocument();
     expect(screen.getByRole("list", { name: "Преимущества магазина" })).toBeInTheDocument();
-    expect(screen.getByText("Цены рассчитывает сервер")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Цены рассчитывает сервер" })).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Следующие преимущества" }));
     expect(scrollBy).toHaveBeenCalledWith({ behavior: "smooth", left: 360 });
+  });
+
+  it("loops back to the original copy at either end", () => {
+    vi.useFakeTimers();
+    render(<StoreHighlights />);
+
+    const list = screen.getByRole("list");
+    const cards = list.querySelectorAll("article");
+
+    Object.defineProperty(list, "offsetLeft", { configurable: true, value: 32 });
+    Object.defineProperty(cards[0], "offsetLeft", { configurable: true, value: 34 });
+    Object.defineProperty(cards[1], "offsetLeft", { configurable: true, value: 134 });
+    Object.defineProperty(cards[4], "offsetLeft", { configurable: true, value: 434 });
+    Object.defineProperty(list, "scrollLeft", { configurable: true, writable: true, value: 2 });
+
+    fireEvent.scroll(list);
+    act(() => vi.advanceTimersByTime(100));
+    expect(list.scrollLeft).toBe(402);
+
+    list.scrollLeft = 200;
+    fireEvent.scroll(list);
+    act(() => vi.advanceTimersByTime(100));
+    expect(list.scrollLeft).toBe(200);
+
+    list.scrollLeft = 802;
+    fireEvent.scroll(list);
+    act(() => vi.advanceTimersByTime(100));
+    expect(list.scrollLeft).toBe(402);
+
+    list.scrollLeft = 3;
+    fireEvent.click(screen.getByRole("button", { name: "Previous advantages" }));
+    expect(list.scrollLeft).toBe(403);
+    expect(scrollBy).toHaveBeenLastCalledWith({ behavior: "smooth", left: -100 });
   });
 });

--- a/frontend/src/components/Home/StoreHighlights/StoreHighlights.tsx
+++ b/frontend/src/components/Home/StoreHighlights/StoreHighlights.tsx
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { useLayoutEffect, useRef } from "react";
 import { FiArrowLeft, FiArrowRight } from "react-icons/fi";
 import { IoCheckmarkCircle } from "react-icons/io5";
 import { useTranslation } from "react-i18next";
@@ -28,15 +28,76 @@ const highlights = [
   },
 ] as const;
 
+const carouselCopies = [0, 1, 2] as const;
+
+const getCarouselMetrics = (list: HTMLDivElement) => {
+  const firstCopy = list.children[0] as HTMLElement | undefined;
+  const secondCard = list.children[1] as HTMLElement | undefined;
+  const originalCopy = list.children[highlights.length] as HTMLElement | undefined;
+
+  if (!firstCopy || !secondCard || !originalCopy) return null;
+
+  const loopWidth = originalCopy.offsetLeft - firstCopy.offsetLeft;
+  const cardStep = secondCard.offsetLeft - firstCopy.offsetLeft;
+  const firstStart = firstCopy.offsetLeft - list.offsetLeft;
+
+  if (loopWidth <= 0) return null;
+
+  return {
+    cardStep,
+    firstStart,
+    loopWidth,
+    originalStart: firstStart + loopWidth,
+  };
+};
+
+const normalizeCarouselPosition = (list: HTMLDivElement) => {
+  const metrics = getCarouselMetrics(list);
+  if (!metrics) return null;
+
+  const boundaryTolerance = Math.max(4, metrics.cardStep * 0.02);
+
+  if (list.scrollLeft <= metrics.firstStart + boundaryTolerance) {
+    list.scrollLeft += metrics.loopWidth;
+  } else if (list.scrollLeft >= metrics.originalStart + metrics.loopWidth - boundaryTolerance) {
+    list.scrollLeft -= metrics.loopWidth;
+  }
+
+  return metrics;
+};
+
 const StoreHighlights = () => {
   const { t } = useTranslation("common");
   const listRef = useRef<HTMLDivElement>(null);
+  const scrollEndTimerRef = useRef<number | null>(null);
+
+  useLayoutEffect(() => {
+    const list = listRef.current;
+    if (list) {
+      const metrics = getCarouselMetrics(list);
+      if (metrics) list.scrollLeft = metrics.originalStart;
+    }
+
+    return () => {
+      if (scrollEndTimerRef.current !== null) window.clearTimeout(scrollEndTimerRef.current);
+    };
+  }, []);
+
+  const handleLoop = () => {
+    if (scrollEndTimerRef.current !== null) window.clearTimeout(scrollEndTimerRef.current);
+
+    scrollEndTimerRef.current = window.setTimeout(() => {
+      const list = listRef.current;
+      if (list) normalizeCarouselPosition(list);
+      scrollEndTimerRef.current = null;
+    }, 100);
+  };
 
   const scroll = (direction: -1 | 1) => {
     const list = listRef.current;
     if (!list) return;
 
-    const distance = list.clientWidth > 0 ? list.clientWidth * 0.8 : 360;
+    const distance = normalizeCarouselPosition(list)?.cardStep || 360;
     list.scrollBy({ behavior: "smooth", left: direction * distance });
   };
 
@@ -56,14 +117,27 @@ const StoreHighlights = () => {
           </div>
         </div>
 
-        <div aria-label={t("highlights.list")} className="store-highlights__list" ref={listRef} role="list">
-          {highlights.map(({ titleKey, descriptionKey }) => (
-            <article className="store-highlights__card" key={titleKey} role="listitem">
-              <IoCheckmarkCircle aria-hidden="true" className="store-highlights__check" />
-              <h3>{t(titleKey)}</h3>
-              <p>{t(descriptionKey)}</p>
-            </article>
-          ))}
+        <div
+          aria-label={t("highlights.list")}
+          className="store-highlights__list"
+          onScroll={handleLoop}
+          ref={listRef}
+          role="list"
+        >
+          {carouselCopies.flatMap((copy) =>
+            highlights.map(({ titleKey, descriptionKey }) => (
+              <article
+                aria-hidden={copy !== 1}
+                className="store-highlights__card"
+                key={`${copy}-${titleKey}`}
+                role="listitem"
+              >
+                <IoCheckmarkCircle aria-hidden="true" className="store-highlights__check" />
+                <h3>{t(titleKey)}</h3>
+                <p>{t(descriptionKey)}</p>
+              </article>
+            ))
+          )}
         </div>
       </PageContainer>
     </section>

--- a/frontend/src/i18n/locales/de/common.ts
+++ b/frontend/src/i18n/locales/de/common.ts
@@ -47,7 +47,6 @@ export const deCommon = {
     signIn: "Anmelden",
     openNamedAccount: "Konto von {{name}} öffnen",
     openAccount: "Dein Konto öffnen",
-    greeting: "Hallo, {{name}}",
     myAccount: "Mein Konto",
     yourAccount: "Dein Konto",
   },

--- a/frontend/src/i18n/locales/en/common.ts
+++ b/frontend/src/i18n/locales/en/common.ts
@@ -45,7 +45,6 @@ export const enCommon = {
     signIn: "Sign in",
     openNamedAccount: "Open {{name}}'s account",
     openAccount: "Open your account",
-    greeting: "Hi, {{name}}",
     myAccount: "My account",
     yourAccount: "Your account",
   },

--- a/frontend/src/i18n/locales/ru/common.ts
+++ b/frontend/src/i18n/locales/ru/common.ts
@@ -47,7 +47,6 @@ export const ruCommon = {
     signIn: "Войти",
     openNamedAccount: "Открыть аккаунт пользователя {{name}}",
     openAccount: "Открыть ваш аккаунт",
-    greeting: "Привет, {{name}}",
     myAccount: "Мой аккаунт",
     yourAccount: "Ваш аккаунт",
   },

--- a/frontend/src/layouts/MainLayout.tsx
+++ b/frontend/src/layouts/MainLayout.tsx
@@ -10,8 +10,8 @@ import "./MainLayout.scss";
 function MainLayout() {
   return (
     <div className="app-shell">
-      <AnnouncementBar />
       <AuthProvider>
+        <AnnouncementBar />
         <CartDataProvider>
           <Header />
           <main className="app-shell__main">

--- a/frontend/src/routes/ScrollToTopLayout.spec.tsx
+++ b/frontend/src/routes/ScrollToTopLayout.spec.tsx
@@ -1,0 +1,44 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes, useNavigate } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ScrollToTopLayout } from "./ScrollToTopLayout";
+
+function NavigationControls() {
+  const navigate = useNavigate();
+
+  return (
+    <button type="button" onClick={() => navigate("/basket")}>
+      Open basket
+    </button>
+  );
+}
+
+describe("ScrollToTopLayout", () => {
+  const scrollTo = vi.fn();
+
+  beforeEach(() => {
+    scrollTo.mockReset();
+    Object.defineProperty(window, "scrollTo", { configurable: true, value: scrollTo, writable: true });
+  });
+
+  it("scrolls to the top when the route changes", async () => {
+    render(
+      <MemoryRouter initialEntries={["/catalog"]}>
+        <Routes>
+          <Route element={<ScrollToTopLayout />}>
+            <Route element={<NavigationControls />} path="*" />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => expect(scrollTo).toHaveBeenCalledTimes(1));
+    expect(scrollTo).toHaveBeenLastCalledWith({ top: 0, left: 0, behavior: "auto" });
+
+    fireEvent.click(screen.getByRole("button", { name: "Open basket" }));
+
+    await waitFor(() => expect(scrollTo).toHaveBeenCalledTimes(2));
+    expect(scrollTo).toHaveBeenLastCalledWith({ top: 0, left: 0, behavior: "auto" });
+  });
+});

--- a/frontend/src/routes/ScrollToTopLayout.tsx
+++ b/frontend/src/routes/ScrollToTopLayout.tsx
@@ -1,0 +1,12 @@
+import { useEffect } from "react";
+import { Outlet, useLocation } from "react-router-dom";
+
+export function ScrollToTopLayout() {
+  const { pathname, search } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo({ top: 0, left: 0, behavior: "auto" });
+  }, [pathname, search]);
+
+  return <Outlet />;
+}

--- a/frontend/src/routes/routesConfig.tsx
+++ b/frontend/src/routes/routesConfig.tsx
@@ -13,44 +13,48 @@ import { actionCustomerData } from "./DataHandlers/Profile/ProfileActions";
 import ProductPage from "../pages/Product/Product";
 import BasketPage from "../pages/Basket/Basket";
 import { GuestOnlyRoute } from "./guards/GuestOnlyRoute";
+import { ScrollToTopLayout } from "./ScrollToTopLayout";
 
 const router = createBrowserRouter(
   [
     {
-      path: "/",
-      Component: MainLayout,
+      Component: ScrollToTopLayout,
       errorElement: <NotFoundPage />,
       children: [
-        { index: true, Component: HomePage },
         {
-          Component: GuestOnlyRoute,
+          path: "/",
+          Component: MainLayout,
+          errorElement: <NotFoundPage />,
           children: [
-            { path: "login", Component: LoginPage },
-            { path: "sign-up", Component: RegistrationPage },
+            { index: true, Component: HomePage },
+            {
+              Component: GuestOnlyRoute,
+              children: [
+                { path: "login", Component: LoginPage },
+                { path: "sign-up", Component: RegistrationPage },
+              ],
+            },
+            {
+              path: "profile",
+              loader: loadCutomerData,
+              action: actionCustomerData,
+              Component: UserPage,
+              errorElement: <ProfileFallBack />,
+            },
+            {
+              path: "catalog/*",
+              Component: CategoryPage,
+            },
+            { path: "product/:id", Component: ProductPage },
+            { path: "about", Component: AboutPage },
+            {
+              path: "basket",
+              Component: BasketPage,
+            },
           ],
         },
-        {
-          path: "profile",
-          loader: loadCutomerData,
-          action: actionCustomerData,
-          Component: UserPage,
-          errorElement: <ProfileFallBack />,
-        },
-        {
-          path: "catalog/*",
-          Component: CategoryPage,
-        },
-        { path: "product/:id", Component: ProductPage },
-        { path: "about", Component: AboutPage },
-        {
-          path: "basket",
-          Component: BasketPage,
-        },
+        { path: "*", Component: NotFoundPage },
       ],
-    },
-    {
-      path: "*",
-      Component: NotFoundPage,
     },
   ],
   {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -17,6 +17,7 @@ export default defineConfig(({ mode }) => ({
   // lint transform keeps standalone service builds independent of root config.
   plugins: [react(), ...(mode === "production" ? [] : [eslint()])],
   server: {
+    host: true,
     proxy: apiProxy,
   },
   preview: {


### PR DESCRIPTION
## Summary

This draft PR brings the latest frontend UX fixes together for review in `develop`.

### Changes

- Hide the registration announcement for authenticated users and avoid a flash while `/auth/me` is checked.
- Reset the scroll position when navigating between internal pages.
- Show the authenticated user's account name in the header.
- Make the “Why Sport Gear” highlights carousel infinite in both directions, with one-card navigation, boundary normalization, and mobile support.
- Add regression coverage for the carousel loop and navigation behavior.
- Ignore Vite's generated `.vite` cache in ESLint and Git checks.
